### PR TITLE
ability to "lynx-like" motion

### DIFF
--- a/plugin/NERD_tree.vim
+++ b/plugin/NERD_tree.vim
@@ -70,6 +70,7 @@ call s:initVariable("g:NERDTreeShowLineNumbers", 0)
 call s:initVariable("g:NERDTreeSortDirs", 1)
 call s:initVariable("g:NERDTreeDirArrows", !s:running_windows)
 call s:initVariable("g:NERDTreeCasadeOpenSingleChildDir", 1)
+call s:initVariable("g:NERDTreeLynxMotion", 0)
 
 if !exists("g:NERDTreeSortOrder")
     let g:NERDTreeSortOrder = ['\/$', '*', '\.swp$',  '\.bak$', '\~$']
@@ -2919,7 +2920,6 @@ function! s:createDefaultBindings()
 
 
     call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapActivateNode, 'scope': "DirNode", 'callback': s."activateDirNode" })
-    call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapActivateNodeAlt, 'scope': "DirNode", 'callback': s."activateDirNode" })
     call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapActivateNode, 'scope': "FileNode", 'callback': s."activateFileNode" })
     call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapActivateNode, 'scope': "Bookmark", 'callback': s."activateBookmark" })
     call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapActivateNode, 'scope': "all", 'callback': s."activateAll" })
@@ -2962,7 +2962,6 @@ function! s:createDefaultBindings()
 
     call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapCloseDir, 'scope': "Node", 'callback': s."closeCurrentDir" })
     call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapCloseChildren, 'scope': "DirNode", 'callback': s."closeChildren" })
-    call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapSlamDir, 'scope': "DirNode", 'callback': s."slamCurrentDir" })
 
     call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapMenu, 'scope': "Node", 'callback': s."showMenu" })
 
@@ -2982,6 +2981,10 @@ function! s:createDefaultBindings()
 
     call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapDeleteBookmark, 'scope': "Bookmark", 'callback': s."deleteBookmark" })
 
+    if g:NERDTreeLynxMotion == 1
+        call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapActivateNodeAlt, 'scope': "DirNode", 'callback': s."activateDirNode" })
+        call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapSlamDir, 'scope': "DirNode", 'callback': s."slamCurrentDir" })
+    endif
 endfunction
 " FUNCTION: s:deprecated(func, [msg]) {{{2
 " Issue a deprecation warning for a:func. If a second arg is given, use this

--- a/plugin/NERD_tree.vim
+++ b/plugin/NERD_tree.vim
@@ -2877,6 +2877,7 @@ function! s:createDefaultBindings()
 
 
     call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapActivateNode, 'scope': "DirNode", 'callback': s."activateDirNode" })
+    call NERDTreeAddKeyMap({ 'key': '<Right>', 'scope': "DirNode", 'callback': s."activateDirNode" })
     call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapActivateNode, 'scope': "FileNode", 'callback': s."activateFileNode" })
     call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapActivateNode, 'scope': "Bookmark", 'callback': s."activateBookmark" })
     call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapActivateNode, 'scope': "all", 'callback': s."activateAll" })
@@ -2917,6 +2918,7 @@ function! s:createDefaultBindings()
 
     call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapCloseDir, 'scope': "Node", 'callback': s."closeCurrentDir" })
     call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapCloseChildren, 'scope': "DirNode", 'callback': s."closeChildren" })
+    call NERDTreeAddKeyMap({ 'key': '<Left>', 'scope': "DirNode", 'callback': s."clozeCurrentDir" })
 
     call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapMenu, 'scope': "Node", 'callback': s."showMenu" })
 
@@ -4054,6 +4056,11 @@ function! s:closeCurrentDir(node)
         call s:renderView()
         call a:node.parent.putCursorHere(0, 0)
     endif
+endfunction
+function! s:clozeCurrentDir(node)
+    call a:node.close()
+    call s:renderView()
+    call a:node.putCursorHere(0, 0)
 endfunction
 " FUNCTION: s:closeTreeWindow() {{{2
 " close the tree window

--- a/plugin/NERD_tree.vim
+++ b/plugin/NERD_tree.vim
@@ -107,10 +107,12 @@ endif
 
 "SECTION: Init variable calls for key mappings {{{2
 call s:initVariable("g:NERDTreeMapActivateNode", "o")
+call s:initVariable("g:NERDTreeMapActivateNodeAlt", "<Right>")
 call s:initVariable("g:NERDTreeMapChangeRoot", "C")
 call s:initVariable("g:NERDTreeMapChdir", "cd")
 call s:initVariable("g:NERDTreeMapCloseChildren", "X")
 call s:initVariable("g:NERDTreeMapCloseDir", "x")
+call s:initVariable("g:NERDTreeMapSlamDir", "<Left>")
 call s:initVariable("g:NERDTreeMapDeleteBookmark", "D")
 call s:initVariable("g:NERDTreeMapMenu", "m")
 call s:initVariable("g:NERDTreeMapHelp", "?")
@@ -2879,7 +2881,7 @@ function! s:createDefaultBindings()
 
 
     call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapActivateNode, 'scope': "DirNode", 'callback': s."activateDirNode" })
-    call NERDTreeAddKeyMap({ 'key': '<Right>', 'scope': "DirNode", 'callback': s."activateDirNode" })
+    call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapActivateNodeAlt, 'scope': "DirNode", 'callback': s."activateDirNode" })
     call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapActivateNode, 'scope': "FileNode", 'callback': s."activateFileNode" })
     call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapActivateNode, 'scope': "Bookmark", 'callback': s."activateBookmark" })
     call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapActivateNode, 'scope': "all", 'callback': s."activateAll" })
@@ -2920,7 +2922,7 @@ function! s:createDefaultBindings()
 
     call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapCloseDir, 'scope': "Node", 'callback': s."closeCurrentDir" })
     call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapCloseChildren, 'scope': "DirNode", 'callback': s."closeChildren" })
-    call NERDTreeAddKeyMap({ 'key': '<Left>', 'scope': "DirNode", 'callback': s."clozeCurrentDir" })
+    call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapSlamDir, 'scope': "DirNode", 'callback': s."slamCurrentDir" })
 
     call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapMenu, 'scope': "Node", 'callback': s."showMenu" })
 
@@ -4062,7 +4064,9 @@ function! s:closeCurrentDir(node)
         call a:node.parent.putCursorHere(0, 0)
     endif
 endfunction
-function! s:clozeCurrentDir(node)
+" FUNCTION: s:slamCurrentDir(node) {{{2
+" closes the current node
+function! s:slamCurrentDir(node)
     call a:node.close()
     call s:renderView()
     call a:node.putCursorHere(0, 0)


### PR DESCRIPTION
behavior: [only] on directory node right arrow(<Right>) opens it, left arrow(<Left>) closes without affecting child nodes state. Came from midnight commander's "Lynx-like motion" option.

P.S.
I'm not sure is this done right, maybe it make sense to add to README (or wiki) "howto" about extending nerdtree to have this functionality. So, what do you think?
