### PR TITLE
fix about windows UNC paths.

### DIFF
--- a/plugin/NERD_tree.vim
+++ b/plugin/NERD_tree.vim
@@ -2740,7 +2740,7 @@ endfunction
 "Return: the string for this path that is suitable to be used with the :edit
 "command
 function! s:Path._strForEdit()
-    let p = escape(self.drive . s:Path.Slash() . self.str({'format': 'UI'}), s:escape_chars)
+    let p = escape(self.drive . self.str({'format': 'UI'}), s:escape_chars)
     let cwd = getcwd() . s:Path.Slash()
 
     "return a relative path if we can

--- a/plugin/NERD_tree.vim
+++ b/plugin/NERD_tree.vim
@@ -2740,7 +2740,7 @@ endfunction
 "Return: the string for this path that is suitable to be used with the :edit
 "command
 function! s:Path._strForEdit()
-    let p = escape(self.str({'format': 'UI'}), s:escape_chars)
+    let p = escape(self.drive . s:Path.Slash() . self.str({'format': 'UI'}), s:escape_chars)
     let cwd = getcwd() . s:Path.Slash()
 
     "return a relative path if we can


### PR DESCRIPTION
nerdtree can't open files in windows UNC paths. it should prepend UNC drive into _strForEdit.
