### PR TITLE
A settings to hide symlink label decorator

### DIFF
--- a/doc/NERD_tree.txt
+++ b/doc/NERD_tree.txt
@@ -599,6 +599,8 @@ NERD tree. These options should be set in your vimrc.
 |'NERDChristmasTree'|           Tells the NERD tree to make itself colourful
                                 and pretty.
 
+|'NERDTreeShowSymlinks'|        Display symlink's original locations.
+
 |'NERDTreeAutoCenter'|          Controls whether the NERD tree window centers
                                 when the cursor moves within a specified
                                 distance to the top/bottom of the window.
@@ -648,7 +650,7 @@ NERD tree. These options should be set in your vimrc.
 |'NERDTreeWinSize'|             Sets the window size when the NERD tree is
                                 opened.
 
-|'NERDTreeMinimalUI'|           Disables display of the 'Bookmarks' label and 
+|'NERDTreeMinimalUI'|           Disables display of the 'Bookmarks' label and
                                 'Press ? for help' text.
 
 |'NERDTreeDirArrows'|           Tells the NERD tree to use arrows instead of
@@ -658,7 +660,7 @@ NERD tree. These options should be set in your vimrc.
                                 Casade open while selected directory has only
                                 one child that also is a directory.
 
-|'NERDTreeAutoDeleteBuffer'|    Tells the NERD tree to automatically remove 
+|'NERDTreeAutoDeleteBuffer'|    Tells the NERD tree to automatically remove
                                 a buffer when a file is being deleted or renamed
                                 via a context menu command.
 
@@ -682,6 +684,14 @@ If this option is set to 1 then some extra syntax highlighting elements are
 added to the nerd tree to make it more colourful.
 
 Set it to 0 for a more vanilla looking tree.
+
+------------------------------------------------------------------------------
+                                                      *'NERDTreeShowSymlinks'*
+Values: 0 or 1.
+Default: 1.
+
+If this option is set to 1 and file node is a symlink, an arrow is added to the
+node pointing to original location.
 
 ------------------------------------------------------------------------------
                                                         *'NERDTreeAutoCenter'*

--- a/nerdtree_plugin/fs_menu.vim
+++ b/nerdtree_plugin/fs_menu.vim
@@ -24,7 +24,7 @@ call NERDTreeAddMenuItem({'text': '(a)dd a childnode', 'shortcut': 'a', 'callbac
 call NERDTreeAddMenuItem({'text': '(m)ove the current node', 'shortcut': 'm', 'callback': 'NERDTreeMoveNode'})
 call NERDTreeAddMenuItem({'text': '(d)elete the current node', 'shortcut': 'd', 'callback': 'NERDTreeDeleteNode'})
 
-if has("gui_mac") || has("gui_macvim") 
+if has("gui_mac") || has("gui_macvim")
     call NERDTreeAddMenuItem({'text': '(r)eveal in Finder the current node', 'shortcut': 'r', 'callback': 'NERDTreeRevealInFinder'})
     call NERDTreeAddMenuItem({'text': '(o)pen the current node with system editor', 'shortcut': 'o', 'callback': 'NERDTreeExecuteFile'})
     call NERDTreeAddMenuItem({'text': '(q)uicklook the current node', 'shortcut': 'q', 'callback': 'NERDTreeQuickLook'})
@@ -71,7 +71,8 @@ function! s:promptToDelBuffer(bufnum, msg)
     endif
 endfunction
 
-"FUNCTION: s:promptToRenameBuffer(bufnum, msg){{{1
+"FUNCTION: s
+":promptToRenameBuffer(bufnum, msg){{{1
 "prints out the given msg and, if the user responds by pushing 'y' then the
 "buffer with the given bufnum is replaced with a new one
 "
@@ -82,13 +83,16 @@ endfunction
 function! s:promptToRenameBuffer(bufnum, msg, newFileName)
     echo a:msg
     if g:NERDTreeAutoDeleteBuffer || nr2char(getchar()) ==# 'y'
+        " YB Escape spaces in filename
+        let newFileName = substitute(a:newFileName, ' ', '\\ ', 'g')
+
         " 1. ensure that a new buffer is loaded
-        exec "badd " . a:newFileName
+        exec "badd " . newFileName
         " 2. ensure that all windows which display the just deleted filename
-        " display a buffer for a new filename. 
+        " display a buffer for a new filename.
         let s:originalTabNumber = tabpagenr()
         let s:originalWindowNumber = winnr()
-        exec "tabdo windo if winbufnr(0) == " . a:bufnum . " | exec ':e! " . a:newFileName . "' | endif"
+        exec "tabdo windo if winbufnr(0) == " . a:bufnum . " | exec ':e! ". newFileName . "' | endif"
         exec "tabnext " . s:originalTabNumber
         exec s:originalWindowNumber . "wincmd w"
         " 3. We don't need a previous buffer anymore

--- a/plugin/NERD_tree.vim
+++ b/plugin/NERD_tree.vim
@@ -70,6 +70,7 @@ call s:initVariable("g:NERDTreeShowLineNumbers", 0)
 call s:initVariable("g:NERDTreeSortDirs", 1)
 call s:initVariable("g:NERDTreeDirArrows", !s:running_windows)
 call s:initVariable("g:NERDTreeCasadeOpenSingleChildDir", 1)
+call s:initVariable("g:NERDTreeShowSymlinks", 1)
 
 if !exists("g:NERDTreeSortOrder")
     let g:NERDTreeSortOrder = ['\/$', '*', '\.swp$',  '\.bak$', '\~$']
@@ -2207,7 +2208,7 @@ function! s:Path.cacheDisplayString()
         let self.cachedDisplayString .= ' {' . join(self._bookmarkNames) . '}'
     endif
 
-    if self.isSymLink
+    if g:NERDTreeShowSymlinks && self.isSymLink
         let self.cachedDisplayString .=  ' -> ' . self.symLinkDest
     endif
 

--- a/syntax/nerdtree.vim
+++ b/syntax/nerdtree.vim
@@ -35,11 +35,14 @@ syn match NERDTreeLink #[^-| `].* -> # contains=NERDTreeBookmark,NERDTreeOpenabl
 
 "highlighing for directory nodes and file nodes
 syn match NERDTreeDirSlash #/#
-syn match NERDTreeDir #[^-| `].*/# contains=NERDTreeLink,NERDTreeDirSlash,NERDTreeOpenable,NERDTreeClosable
-syn match NERDTreeExecFile  #[|` ].*\*\($\| \)# contains=NERDTreeLink,NERDTreePart,NERDTreeRO,NERDTreePartFile,NERDTreeBookmark
+syn match NERDTreeDir #[^-| `].*/# contains=NERDTreeLink,NERDTreeDirSlash,NERDTreeOpenable,NERDTreeClosable,NERDTreeMtf
+syn match NERDTreeDir1 # \{2\}[^-| `].*/# contains=NERDTreeLink,NERDTreeDirSlash,NERDTreeOpenable,NERDTreeClosable,NERDTreeMtf
+syn match NERDTreeDir2 # \{4\}[^-| `].*/# contains=NERDTreeLink,NERDTreeDirSlash,NERDTreeOpenable,NERDTreeClosable,NERDTreeMtf
+syn match NERDTreeDir3 # \{6\}[^-| `].*/# contains=NERDTreeLink,NERDTreeDirSlash,NERDTreeOpenable,NERDTreeClosable,NERDTreeMtf
 syn match NERDTreeFile  #|-.*# contains=NERDTreeLink,NERDTreePart,NERDTreeRO,NERDTreePartFile,NERDTreeBookmark,NERDTreeExecFile
 syn match NERDTreeFile  #`-.*# contains=NERDTreeLink,NERDTreePart,NERDTreeRO,NERDTreePartFile,NERDTreeBookmark,NERDTreeExecFile
 syn match NERDTreeCWD #^[</].*$#
+syn match NERDTreeExecFile #\*#
 
 "highlighting for bookmarks
 syn match NERDTreeBookmark # {.*}#hs=s+1


### PR DESCRIPTION
This is a simple adding of a new setting to hide symlink label decorator. As I use symlinks a lot, display bunch arrows is a bit too much for me :)