### PR TITLE
Add support for copy on Windows systems

### DIFF
--- a/lib/nerdtree/path.vim
+++ b/lib/nerdtree/path.vim
@@ -188,7 +188,7 @@ function! s:Path.copy(dest)
         endif
     else
         let cmd_prefix = g:NERDTreeCopyCmd
-    end
+    endif
 
     let cmd = cmd_prefix . " " . escape(self.str(), self._escChars()) . " " . escape(dest, self._escChars())
     let success = system(cmd)

--- a/plugin/NERD_tree.vim
+++ b/plugin/NERD_tree.vim
@@ -103,6 +103,8 @@ call s:initVariable("g:NERDTreeWinSize", 31)
 "Note: the space after the command is important
 if nerdtree#runningWindows()
     call s:initVariable("g:NERDTreeRemoveDirCmd", 'rmdir /s /q ')
+    call s:initVariable("g:NERDTreeCopyDirCmd", 'xcopy /s /e /i /y /q ')
+    call s:initVariable("g:NERDTreeCopyFileCmd", 'copy /y ')
 else
     call s:initVariable("g:NERDTreeRemoveDirCmd", 'rm -rf ')
     call s:initVariable("g:NERDTreeCopyCmd", 'cp -r ')


### PR DESCRIPTION
I've added support for copying files and directories on Windows systems through the `copy` and `xcopy` DOS commands. I also fixed a bug for the success check in the `Path.copy` function by replacing `success != 0` with `v:shell_error != 0`; I believe this fix represents the intended functionality.

My code has been tested on Windows XP SP3, Windows 8, and Mac OS X 10.6. Mac (Unix) functionality has remained unchanged.