### PR TITLE
Don't ignore autocmd events when close tree

### DIFF
--- a/autoload/nerdtree.vim
+++ b/autoload/nerdtree.vim
@@ -135,7 +135,7 @@ function! nerdtree#closeTree()
 
         call nerdtree#exec(nerdtree#getTreeWinNum() . " wincmd w")
         close
-        call nerdtree#exec(bufwinnr(bufnr) . " wincmd w")
+        execute bufwinnr(bufnr) . " wincmd w"
     else
         close
     endif


### PR DESCRIPTION
I (and maybe some users) have the following setting

```vim
autocmd WinEnter * setlocal cursorline
autocmd WinLeave * setlocal nocursorline
```

This sets `cursorline` only on the current window.

But, when the NERDTree window closed, `cursorline` appears on not-current window because WinEnter/WinLeave events are ignored.

In addition, same issue will occur when using [Powerline](https://github.com/Lokaltog/powerline).
`Powerline` handles 'statusline' in the same way.

This PR makes tree window fire the autocmd events when closed.