### PR TITLE
Reverted saveScreenState to BufWinLeave and fixed bug causing errors.

### DIFF
--- a/plugin/NERD_tree.vim
+++ b/plugin/NERD_tree.vim
@@ -148,7 +148,7 @@ call nerdtree#ui_glue#setupCommands()
 "============================================================
 augroup NERDTree
     "Save the cursor position whenever we close the nerd tree
-    exec "autocmd BufLeave ". g:NERDTreeCreator.BufNamePrefix() ."* call b:NERDTree.ui.saveScreenState()"
+    exec "autocmd BufWinLeave ". g:NERDTreeCreator.BufNamePrefix() ."* call getbufvar(expand('<afile>'), 'NERDTree').ui.saveScreenState()"
 
     "disallow insert mode in the NERDTree
     exec "autocmd BufEnter ". g:NERDTreeCreator.BufNamePrefix() ."* stopinsert"


### PR DESCRIPTION
The reason of the error messages with BufWinLeave was that current buffer may differ from one being unloaded.
Here is note from BufWinLeave help:
>NOTE: When this autocommand is executed, the
>current buffer "%" may be different from the
>buffer being unloaded "\<afile\>".

I didn't look down into codes, but based on "saveScreenState()" name BufWinLeave is more appropriate, since it called only once when buffer is closed.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/scrooloose/nerdtree/366)
<!-- Reviewable:end -->
