### PR TITLE
New configuration option: NERDTreeActivateFileMode

### DIFF
--- a/autoload/nerdtree/ui_glue.vim
+++ b/autoload/nerdtree/ui_glue.vim
@@ -99,7 +99,7 @@ endfunction
 "FUNCTION: s:activateFileNode() {{{1
 "handle the user activating a tree node
 function! s:activateFileNode(node)
-    call a:node.activate({'reuse': 'all', 'where': 'p'})
+    call a:node.activate({'reuse': 'all', 'where': g:NERDTreeActivateFileMode})
 endfunction
 
 "FUNCTION: s:activateBookmark() {{{1

--- a/doc/NERD_tree.txt
+++ b/doc/NERD_tree.txt
@@ -684,6 +684,9 @@ NERD tree. These options should be set in your vimrc.
                                 a buffer when a file is being deleted or renamed
                                 via a context menu command.
 
+|'NERDTreeActivateFileMode'|    Sets the default behaviour, when activating a
+                                file node in the tree window.
+
 ------------------------------------------------------------------------------
 3.2. Customisation details                             *NERDTreeOptionDetails*
 
@@ -1027,6 +1030,21 @@ then it worths to set this option to 1. Use one of the follow lines to set this
 option: >
     let NERDTreeAutoDeleteBuffer=0
     let NERDTreeAutoDeleteBuffer=1
+<
+
+------------------------------------------------------------------------------
+                                          *'NERDTreeActivateFileMode'*
+Values: 'p', 'h', 'v' or 't'
+Default: 'p'.
+
+You may want to change the default behaviour when activating a file node from
+the tree. 'p' will replace the content of the current file buffer, 'h' will
+perform a horzintal split, 'v' will perform a vertical split and 't' will open
+a new tab. Use one of the follow lines to set this option: >
+    let NERDTreeActivateFileMode='p'
+    let NERDTreeActivateFileMode='h'
+    let NERDTreeActivateFileMode='v'
+    let NERDTreeActivateFileMode='t'
 <
 
 ==============================================================================

--- a/plugin/NERD_tree.vim
+++ b/plugin/NERD_tree.vim
@@ -69,6 +69,7 @@ call s:initVariable("g:NERDTreeShowLineNumbers", 0)
 call s:initVariable("g:NERDTreeSortDirs", 1)
 call s:initVariable("g:NERDTreeDirArrows", !nerdtree#runningWindows())
 call s:initVariable("g:NERDTreeCascadeOpenSingleChildDir", 1)
+call s:initVariable("g:NERDTreeActivateFileMode", 'p')
 
 if !exists("g:NERDTreeSortOrder")
     let g:NERDTreeSortOrder = ['\/$', '*', '\.swp$',  '\.bak$', '\~$']


### PR DESCRIPTION
Hi,

_The original commits are not valid anymore, see my second comment for the current decription_

~~I've made some small changes to make NERDTree open every file in a new window. This way every file will stay opened until closed explicitly. If a file has already been opened in a window, this window will be brought to front instead of creating a new one. I'm using NERDTreeAlwaysSplit for about two years now and really like it, because it creates some kind of "tab-like" feeling.~~ 

~~As you can see in commit e77accd the changes in the code are really small and the always split functionality is disabled by default. In the two years of using my patch I never experienced any bugs or side-effects caused by my changes.~~ 

Hope hearing from you :)

Baibai
Torben
