### PR TITLE
Fix for nonexistent dir/bookmarks given to NERDTree commands

### DIFF
--- a/lib/nerdtree/creator.vim
+++ b/lib/nerdtree/creator.vim
@@ -42,6 +42,11 @@ endfunction
 "name: the name of a bookmark or a directory
 function! s:Creator.createPrimary(name)
     let path = self._pathForString(a:name)
+    
+    "abort if exception was thrown (bookmark/dir doesn't exist)
+    if empty(path)
+        return
+    endif
 
     "if instructed to, then change the vim CWD to the dir the NERDTree is
     "inited in


### PR DESCRIPTION
* Return early if exception was thrown in pathForString
* Stops a bunch of error messages getting printed onto the screen if you give the NERDTree, NERDTreeFromBookmark and NERDTreeToggle commands a dir/bookmark that doesn't exist (which also puts the plugin into an inconsistent state)