### PR TITLE
Added NERDTreeNoSwitchTabs option.

### DIFF
--- a/doc/NERD_tree.txt
+++ b/doc/NERD_tree.txt
@@ -682,6 +682,9 @@ NERD tree. These options should be set in your vimrc.
                                 a buffer when a file is being deleted or renamed
                                 via a context menu command.
 
+|'NERDTreeNoSwitchTabs'|        Tells the NERD tree whether to reuse a window
+                                in another tab.
+
 ------------------------------------------------------------------------------
 3.2. Customisation details                             *NERDTreeOptionDetails*
 
@@ -1025,6 +1028,19 @@ then it worths to set this option to 1. Use one of the follow lines to set this
 option: >
     let NERDTreeAutoDeleteBuffer=0
     let NERDTreeAutoDeleteBuffer=1
+<
+
+------------------------------------------------------------------------------
+                                          *'NERDTreeNoSwitchTabs'*
+Values: 0 or 1
+Default: 0.
+
+When you open a file node, NERDTree also checks if that file is already open
+in another tab and switches to that tab, if so. If you want to prevent
+NERDTree from switching tabs, set this option to 1. Use one of the follow
+lines to set this option: >
+    let NERDTreeNoSwitchTabs=0
+    let NERDTreeNoSwitchTabs=1
 <
 
 ==============================================================================

--- a/lib/nerdtree/opener.vim
+++ b/lib/nerdtree/opener.vim
@@ -313,8 +313,8 @@ function! s:Opener._reuseWindow()
         call nerdtree#exec(winnr . "wincmd w")
         call self._checkToCloseTree(0)
         return 1
-    else
-        "check other tabs
+    elseif g:NERDTreeNoSwitchTabs ==# 0
+        "check other tabs unless NERDTreeNoSwitchTabs is enabled
         let tabnr = self._path.tabnr()
         if tabnr
             call self._checkToCloseTree(1)

--- a/plugin/NERD_tree.vim
+++ b/plugin/NERD_tree.vim
@@ -69,6 +69,7 @@ call s:initVariable("g:NERDTreeShowLineNumbers", 0)
 call s:initVariable("g:NERDTreeSortDirs", 1)
 call s:initVariable("g:NERDTreeDirArrows", !nerdtree#runningWindows())
 call s:initVariable("g:NERDTreeCascadeOpenSingleChildDir", 1)
+call s:initVariable("g:NERDTreeNoSwitchTabs", 0)
 
 if !exists("g:NERDTreeSortOrder")
     let g:NERDTreeSortOrder = ['\/$', '*', '\.swp$',  '\.bak$', '\~$']


### PR DESCRIPTION
In NERDTree, if I select a file node and hit "o", it opens the file in a window in the current tab. However, if that file is already open in another tab, NERDTree switches to that tab to reuse the window. I find that this disrupts my workflow.

I asked if there's a way to prevent tab switching on [vi StackExchange](http://vi.stackexchange.com/questions/716/prevent-nerdtree-from-switching-tabs-when-opening-a-file-node), but there was no simple answer. So I decided to implement this option myself. And here are my changes.
