### PR TITLE
Use different arrow characters for compatibility.

### DIFF
--- a/autoload/nerdtree.vim
+++ b/autoload/nerdtree.vim
@@ -98,7 +98,7 @@ endfunction
 "FUNCTION: nerdtree#treeMarkupReg(dir) {{{2
 function! nerdtree#treeMarkupReg()
     if g:NERDTreeDirArrows
-        return '^\([▾▸] \| \+[▾▸] \| \+\)'
+        return '^\([▼▶] \| \+[▼▶] \| \+\)'
     endif
 
     return '^[ `|]*[\-+~]'

--- a/lib/nerdtree/tree_file_node.vim
+++ b/lib/nerdtree/tree_file_node.vim
@@ -383,13 +383,13 @@ function! s:TreeFileNode._renderToString(depth, drawText, vertMap, isLastChild)
         if self.path.isDirectory
             if self.isOpen
                 if g:NERDTreeDirArrows
-                    let treeParts = treeParts . '▾ '
+                    let treeParts = treeParts . '▼ '
                 else
                     let treeParts = treeParts . '~'
                 endif
             else
                 if g:NERDTreeDirArrows
-                    let treeParts = treeParts . '▸ '
+                    let treeParts = treeParts . '▶ '
                 else
                     let treeParts = treeParts . '+'
                 endif

--- a/lib/nerdtree/ui.vim
+++ b/lib/nerdtree/ui.vim
@@ -51,7 +51,7 @@ function! s:UI.getPath(ln)
 
     if !g:NERDTreeDirArrows
         " in case called from outside the tree
-        if line !~# '^ *[|`▸▾ ]' || line =~# '^$'
+        if line !~# '^ *[|`▶▼ ]' || line =~# '^$'
             return {}
         endif
     endif
@@ -159,9 +159,9 @@ endfunction
 
 "FUNCTION: s:UI._indentLevelFor(line) {{{2
 function! s:UI._indentLevelFor(line)
-    let level = match(a:line, '[^ \-+~▸▾`|]') / nerdtree#treeWid()
+    let level = match(a:line, '[^ \-+~▶▼`|]') / nerdtree#treeWid()
     " check if line includes arrows
-    if match(a:line, '[▸▾]') > -1
+    if match(a:line, '[▶▼]') > -1
         " decrement level as arrow uses 3 ascii chars
         let level = level - 1
     endif

--- a/syntax/nerdtree.vim
+++ b/syntax/nerdtree.vim
@@ -23,12 +23,12 @@ syn match NERDTreeLinkDir #.*/ ->#me=e-3 containedin=NERDTreeDir
 syn match NERDTreeDirSlash #/# containedin=NERDTreeDir
 
 if g:NERDTreeDirArrows
-    syn match NERDTreeClosable #▾# containedin=NERDTreeDir,NERDTreeFile
-    syn match NERDTreeOpenable #▸# containedin=NERDTreeDir,NERDTreeFile
+    syn match NERDTreeClosable #▼# containedin=NERDTreeDir,NERDTreeFile
+    syn match NERDTreeOpenable #▶# containedin=NERDTreeDir,NERDTreeFile
 
-    syn match NERDTreeDir #[^▾▸ ].*/#
+    syn match NERDTreeDir #[^▼▶ ].*/#
     syn match NERDTreeExecFile  #^ .*\*\($\| \)# contains=NERDTreeRO,NERDTreeBookmark
-    syn match NERDTreeFile  #^[^"\.▾▸] *[^▾▸]*# contains=NERDTreeLink,NERDTreeRO,NERDTreeBookmark,NERDTreeExecFile
+    syn match NERDTreeFile  #^[^"\.▼▶] *[^▼▶]*# contains=NERDTreeLink,NERDTreeRO,NERDTreeBookmark,NERDTreeExecFile
 
     "highlighting for readonly files
     syn match NERDTreeRO # *\zs.*\ze \[RO\]# contains=NERDTreeIgnore,NERDTreeBookmark,NERDTreeFile


### PR DESCRIPTION
The "small arrow" characters used (u+25b8 and u+25be) don't seem to render properly on Windows using the Source Code Pro font in PuTTY (I've noticed this with other fonts as well).  On other systems they seem to render properly.  This patch uses larger arrow characters (u+25b6 and u+25bc) that seem to render consistently on Windows, Mac, and Linux.