### PR TITLE
Option NERDTreeOpenTabAtTheEnd opens tabs at the end of the tab bar

### DIFF
--- a/doc/NERD_tree.txt
+++ b/doc/NERD_tree.txt
@@ -1040,6 +1040,19 @@ tree window using `silent keepalt keepjumps edit`:
     let NERDTreeCreatePrefix='silent keepalt keepjumps'
 <
 
+------------------------------------------------------------------------------
+                                          *'NERDTreeOpenTabAtTheEnd'*
+Values: 0 or 1
+Default: 0.
+
+When opening a file in a new tab, usually the tab is put after the current
+tab. If the option is set to 1, the tab will be opened after the last tab.
+Use one of the follow lines to set this option: >
+    let NERDTreeOpenTabAtTheEnd=0
+    let NERDTreeOpenTabAtTheEnd=1
+<
+
+
 ==============================================================================
 4. The NERD tree API                                             *NERDTreeAPI*
 

--- a/lib/nerdtree/opener.vim
+++ b/lib/nerdtree/opener.vim
@@ -70,7 +70,11 @@ function! s:Opener._gotoTargetWin()
         elseif self._where == 'h'
             split
         elseif self._where == 't'
-            tabnew
+            if g:NERDTreeOpenTabAtTheEnd
+                $tabnew
+            else
+                tabnew
+            endif
         endif
     else
         call self._checkToCloseTree(1)
@@ -80,7 +84,11 @@ function! s:Opener._gotoTargetWin()
         elseif self._where == 'h'
             call self._newSplit()
         elseif self._where == 't'
-            tabnew
+            if g:NERDTreeOpenTabAtTheEnd
+                $tabnew
+            else
+                tabnew
+            endif
         elseif self._where == 'p'
             call self._previousWindow()
         endif

--- a/plugin/NERD_tree.vim
+++ b/plugin/NERD_tree.vim
@@ -76,6 +76,7 @@ else
 endif
 call s:initVariable("g:NERDTreeCascadeOpenSingleChildDir", 1)
 call s:initVariable("g:NERDTreeCascadeSingleChildDir", 1)
+call s:initVariable("g:NERDTreeOpenTabAtTheEnd", 0)
 
 if !exists("g:NERDTreeSortOrder")
     let g:NERDTreeSortOrder = ['\/$', '*', '\.swp$',  '\.bak$', '\~$']


### PR DESCRIPTION
Make it configurable to open a file in a tab after the last tab with the option g:NERDTreeOpenTabAtTheEnd.

What this basically does is calling `$tabnew` instead of calling `tabnew`.
See https://neovim.io/doc/user/tabpage.html#tab-page-commands for info
