### PR TITLE
Fixed case-sensitive sorting of tree nodes when 'ignorecase' option is on

### DIFF
--- a/autoload/nerdtree.vim
+++ b/autoload/nerdtree.vim
@@ -36,9 +36,9 @@ endfunction
 
 "FUNCTION: nerdtree#compareNodesBySortKey(n1, n2) {{{2
 function! nerdtree#compareNodesBySortKey(n1, n2)
-    if a:n1.path.getSortKey() < a:n2.path.getSortKey()
+    if a:n1.path.getSortKey() <# a:n2.path.getSortKey()
         return -1
-    elseif a:n1.path.getSortKey() > a:n2.path.getSortKey()
+    elseif a:n1.path.getSortKey() ># a:n2.path.getSortKey()
         return 1
     else
         return 0


### PR DESCRIPTION
Looks like NERD tree always sorts tree nodes case-insensitively when ```ignorecase``` option is on, even if ```NERDTreeCaseSensitiveSort``` is set to 1.

It happens because recently added ```nerdtree#compareNodesBySortKey``` uses plain <, > operators that depend of ```ignorecase```:
```
function! nerdtree#compareNodesBySortKey(n1, n2)
    if a:n1.path.getSortKey() < a:n2.path.getSortKey()
        return -1
    elseif a:n1.path.getSortKey() > a:n2.path.getSortKey()
        return 1
    else
        return 0
    endif
endfunction
```
Fixed the issue by replacing <, > with <#, >#. We can safely do this since ```getSortKey``` already handles ```NERDTreeCaseSensitiveSort``` for us by converting paths to lower case when needed.