### PR TITLE
Don't require user to type 'yes' to delete an empty directory

### DIFF
--- a/nerdtree_plugin/fs_menu.vim
+++ b/nerdtree_plugin/fs_menu.vim
@@ -160,7 +160,7 @@ function! NERDTreeDeleteNode()
     let currentNode = g:NERDTreeFileNode.GetSelected()
     let confirmed = 0
 
-    if currentNode.path.isDirectory
+    if currentNode.path.isDirectory && currentNode.getChildCount() > 0
         let choice =input("Delete the current node\n" .
                          \ "==========================================================\n" .
                          \ "STOP! To delete this entire directory, type 'yes'\n" .


### PR DESCRIPTION
It will use the normal "yN" delete prompt instead.

My reasoning is that if you expect that the directory is empty, and you see the "STOP!" prompt, you might get concerned that it's not actually empty and waste a couple of seconds going back and checking.

Potential concerns: if you were used to typing "yes", you might end up typing y, which would confirm deletion, then e, and then s, which would open the file that's now under your cursor in a new split. This could be mildly annoying if you were very accustomed to the way NERDTree works now.