### PR TITLE
Fixed windows arrow configuration if-statement

### DIFF
--- a/plugin/NERD_tree.vim
+++ b/plugin/NERD_tree.vim
@@ -67,11 +67,11 @@ call s:initVariable("g:NERDTreeShowLineNumbers", 0)
 call s:initVariable("g:NERDTreeSortDirs", 1)
 
 if !nerdtree#runningWindows()
-    call s:initVariable("g:NERDTreeDirArrowExpandable", "▸")
-    call s:initVariable("g:NERDTreeDirArrowCollapsible", "▾")
-else
     call s:initVariable("g:NERDTreeDirArrowExpandable", "+")
     call s:initVariable("g:NERDTreeDirArrowCollapsible", "~")
+else
+    call s:initVariable("g:NERDTreeDirArrowExpandable", "▸")
+    call s:initVariable("g:NERDTreeDirArrowCollapsible", "▾")
 endif
 call s:initVariable("g:NERDTreeCascadeOpenSingleChildDir", 1)
 


### PR DESCRIPTION
Original if-statement was swapped for windows and non-windows, resulting in defaulting to fancy arrows for windows.