### PR TITLE
changed arrows for NERDTreeDirArrowExpandable and NERDTreeDirArrowCol…

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -118,5 +118,5 @@ See here: https://github.com/scrooloose/nerdtree/issues/433#issuecomment-9259069
 
 Use these variables in your vimrc. Note that below are default arrow symbols
 
-    let g:NERDTreeDirArrowExpandable = '▸'
-    let g:NERDTreeDirArrowCollapsible = '▾'
+    let g:NERDTreeDirArrowExpandable = '►'
+    let g:NERDTreeDirArrowCollapsible = '▼'

--- a/plugin/NERD_tree.vim
+++ b/plugin/NERD_tree.vim
@@ -67,8 +67,8 @@ call s:initVariable("g:NERDTreeShowLineNumbers", 0)
 call s:initVariable("g:NERDTreeSortDirs", 1)
 
 if !nerdtree#runningWindows()
-    call s:initVariable("g:NERDTreeDirArrowExpandable", "▸")
-    call s:initVariable("g:NERDTreeDirArrowCollapsible", "▾")
+    call s:initVariable("g:NERDTreeDirArrowExpandable", "►")
+    call s:initVariable("g:NERDTreeDirArrowCollapsible", "▼")
 else
     call s:initVariable("g:NERDTreeDirArrowExpandable", "+")
     call s:initVariable("g:NERDTreeDirArrowCollapsible", "~")


### PR DESCRIPTION
…lapsible
Arrows used so far ('▸' unicode 9656 and '▾' unicode 9662) can't be find in popular monotype fonts like Courier New, Liberation Mono or Lucida Console (while available in DejaVu Sans Mono or Consolas)
Characters '►' (unicode 9658) and '▼' (unicode 9660) are much more popular.