### PR TITLE
Issue #537: Fix dir arrows not functioning properly

### DIFF
--- a/syntax/nerdtree.vim
+++ b/syntax/nerdtree.vim
@@ -25,7 +25,7 @@ syn match NERDTreeDirSlash #/# containedin=NERDTreeDir
 exec 'syn match NERDTreeClosable #'.escape(g:NERDTreeDirArrowCollapsible, '~').'# containedin=NERDTreeDir,NERDTreeFile'
 exec 'syn match NERDTreeOpenable #'.escape(g:NERDTreeDirArrowExpandable, '~').'# containedin=NERDTreeDir,NERDTreeFile'
 
-let s:dirArrows = escape(g:NERDTreeDirArrowCollapsible, '~').escape(g:NERDTreeDirArrowExpandable, '~')
+let s:dirArrows = escape(g:NERDTreeDirArrowCollapsible, '~]\-').escape(g:NERDTreeDirArrowExpandable, '~]\-')
 exec 'syn match NERDTreeDir #[^'.s:dirArrows.' ].*/#'
 syn match NERDTreeExecFile  #^ .*\*\($\| \)# contains=NERDTreeRO,NERDTreeBookmark
 exec 'syn match NERDTreeFile  #^[^"\.'.s:dirArrows.'] *[^'.s:dirArrows.']*# contains=NERDTreeLink,NERDTreeRO,NERDTreeBookmark,NERDTreeExecFile'


### PR DESCRIPTION
added characters that are special when within character
classes in a regular expression to the `escape(...)` call
when building `s:dirArrows`.

this does not fix when `' '` or `''` are your `dirArrows` and you
can't open up subdirs. i think that's an issue with how nerdtree
distinguishes things to traverse in the filetree.

this fixes: https://github.com/scrooloose/nerdtree/issues/537