### PR TITLE
Make window creation command configurable

### DIFF
--- a/doc/NERD_tree.txt
+++ b/doc/NERD_tree.txt
@@ -679,6 +679,9 @@ NERD tree. These options should be set in your vimrc.
                                 a buffer when a file is being deleted or renamed
                                 via a context menu command.
 
+|'NERDTreeCreatePrefix'|        Specify a prefix to be used when creating the
+                                NERDTree window.
+
 ------------------------------------------------------------------------------
 3.2. Customisation details                             *NERDTreeOptionDetails*
 
@@ -1009,6 +1012,17 @@ then it worths to set this option to 1. Use one of the follow lines to set this
 option: >
     let NERDTreeAutoDeleteBuffer=0
     let NERDTreeAutoDeleteBuffer=1
+<
+------------------------------------------------------------------------------
+                                          *'NERDTreeCreatePrefix'*
+Values: Any valid command prefix.
+Default: "silent".
+
+Internally, NERDTree uses the |:edit| command to create a buffer in which to
+display its tree view. You can augment this behavior by specifying a prefix
+string such as "keepalt" or similar. For example, to have NERDTree create its
+tree window using `silent keepalt keepjumps edit`:
+    let NERDTreeCreatePrefix='silent keepalt keepjumps'
 <
 
 ==============================================================================

--- a/lib/nerdtree/creator.vim
+++ b/lib/nerdtree/creator.vim
@@ -96,7 +96,8 @@ function! s:Creator.createWindowTree(dir)
 
     "we need a unique name for each window tree buffer to ensure they are
     "all independent
-    exec "silent edit " . self._nextBufferName()
+    let prefix = get(g:, "NERDTreeCreatePrefix", "silent")
+    exec prefix . " edit " . self._nextBufferName()
 
     call self._createNERDTree(path, "window")
     let b:NERDTree._previousBuf = bufnr(previousBuf)


### PR DESCRIPTION
This commit adds a `NERDTreeCreatePrefix` setting that can be used to
prefix the `:edit` command that is used to create the NERDTree tree
window. Defaults to "silent", meaning that out of the box the window
will be created with "silent edit".

Users may wish to configure this to produce other effects. For example,
`NERDTreeCreatePrefix` can be set to "silent keepalt keepjumps" in order
to make NERDTree create its window with "silent keepalt keepjumps edit".

This can be used to create an effect analogous to the `g:netrw_altfile`
setting in netrw. An example of why you might want to do this is
described here:

    https://github.com/tpope/vim-vinegar/issues/25

I'm not using vim-vinegar myself, but I am using something like it here:

    https://github.com/wincent/wincent/blob/3efaa8fa50895/roles/dotfiles/files/.vim/plugin/mappings.vim#L60

And having `NERDTreeCreatePrefix` enables me to map "-" to show the
current file in context, and `^-6` to jump back to it.