### PR TITLE
Allow user-defined read-only indicator.

### DIFF
--- a/lib/nerdtree/path.vim
+++ b/lib/nerdtree/path.vim
@@ -61,7 +61,7 @@ function! s:Path.cacheDisplayString() abort
     endif
 
     if self.isReadOnly
-        let self.cachedDisplayString .=  ' [RO]'
+        let self.cachedDisplayString .=  ' ['.g:NERDTreeGlyphReadOnly.']'
     endif
 endfunction
 

--- a/lib/nerdtree/ui.vim
+++ b/lib/nerdtree/ui.vim
@@ -375,7 +375,7 @@ function! s:UI._stripMarkup(line, removeLeadingSpaces)
     let line = substitute (line, g:NERDTreeUI.MarkupReg(),"","")
 
     "strip off any read only flag
-    let line = substitute (line, ' \[RO\]', "","")
+    exec 'let line = substitute (line, " \['.g:NERDTreeGlyphReadOnly.'\]", "","")'
 
     "strip off any bookmark flags
     let line = substitute (line, ' {[^}]*}', "","")

--- a/plugin/NERD_tree.vim
+++ b/plugin/NERD_tree.vim
@@ -84,6 +84,8 @@ else
     endif
 endif
 
+call s:initVariable("g:NERDTreeGlyphReadOnly", "RO")
+
 if !exists('g:NERDTreeStatusline')
 
     "the exists() crap here is a hack to stop vim spazzing out when

--- a/syntax/nerdtree.vim
+++ b/syntax/nerdtree.vim
@@ -1,6 +1,6 @@
 let s:tree_up_dir_line = '.. (up a dir)'
 syn match NERDTreeIgnore #\~#
-syn match NERDTreeIgnore #\[RO\]#
+exec 'syn match NERDTreeIgnore #\['.g:NERDTreeGlyphReadOnly.'\]#'
 
 "highlighting for the .. (up dir) line at the top of the tree
 execute "syn match NERDTreeUp #\\V". s:tree_up_dir_line ."#"
@@ -31,7 +31,7 @@ syn match NERDTreeExecFile  #^ .*\*\($\| \)# contains=NERDTreeRO,NERDTreeBookmar
 exec 'syn match NERDTreeFile  #^[^"\.'.s:dirArrows.'] *[^'.s:dirArrows.']*# contains=NERDTreeLink,NERDTreeRO,NERDTreeBookmark,NERDTreeExecFile'
 
 "highlighting for readonly files
-syn match NERDTreeRO # *\zs.*\ze \[RO\]# contains=NERDTreeIgnore,NERDTreeBookmark,NERDTreeFile
+exec 'syn match NERDTreeRO # *\zs.*\ze \['.g:NERDTreeGlyphReadOnly.'\]# contains=NERDTreeIgnore,NERDTreeBookmark,NERDTreeFile'
 
 syn match NERDTreeFlags #^ *\zs\[.\]# containedin=NERDTreeFile,NERDTreeExecFile
 syn match NERDTreeFlags #\[.\]# containedin=NERDTreeDir


### PR DESCRIPTION
(inspired by overwriting g:NERDTreeDirArrowCollapsible/Expandable)

Replace instances of the RO string with a variable that the user can
override. Useful for custom unicode glyphs, i.e. Font Awesome.

* Initialize variable g:NERDTreeGlyphReadOnly = "RO".
   -> plugin/NERD_tree.vim
* Replace instances of 'RO' with g:NERDTreeGlyphReadOnly

Preview:
![screen shot 2016-02-26 at 6 02 12 pm](https://cloud.githubusercontent.com/assets/1359902/13370074/2871c3da-dcb3-11e5-83ee-538126f08d4d.png)

> **NOTE** - I left the square brackets around the indicator so users don't have to deal with issues escaping characters.