### PR TITLE
Add option to disable collapsing of directory names

### DIFF
--- a/doc/NERD_tree.txt
+++ b/doc/NERD_tree.txt
@@ -668,14 +668,18 @@ NERD tree. These options should be set in your vimrc.
 |'NERDTreeWinSize'|             Sets the window size when the NERD tree is
                                 opened.
 
-|'NERDTreeMinimalUI'|           Disables display of the 'Bookmarks' label and 
+|'NERDTreeMinimalUI'|           Disables display of the 'Bookmarks' label and
                                 'Press ? for help' text.
+
+|'NERDTreeCascadeSingleChildDir'|
+                                Collapses on the same line directories that
+                                have only one child directory.
 
 |'NERDTreeCascadeOpenSingleChildDir'|
                                 Cascade open while selected directory has only
                                 one child that also is a directory.
 
-|'NERDTreeAutoDeleteBuffer'|    Tells the NERD tree to automatically remove 
+|'NERDTreeAutoDeleteBuffer'|    Tells the NERD tree to automatically remove
                                 a buffer when a file is being deleted or renamed
                                 via a context menu command.
 
@@ -984,7 +988,18 @@ of the following lines to set this option: >
 <
 
 ------------------------------------------------------------------------------
-                                          *'NERDTreeCascadeOpenSingleChildDir'*
+                                             *'NERDTreeCascadeSingleChildDir'*
+Values: 0 or 1
+Default: 1.
+
+When displaying dir nodes, this option tells NERDTree to collapse dirs that
+have only one child. Use one of the follow lines to set this option: >
+    let NERDTreeCascadeSingleChildDir=0
+    let NERDTreeCascadeSingleChildDir=1
+<
+
+------------------------------------------------------------------------------
+                                         *'NERDTreeCascadeOpenSingleChildDir'*
 Values: 0 or 1
 Default: 1.
 
@@ -998,7 +1013,7 @@ useful for Java projects. Use one of the follow lines to set this option: >
 <
 
 ------------------------------------------------------------------------------
-                                          *'NERDTreeAutoDeleteBuffer'*
+                                                  *'NERDTreeAutoDeleteBuffer'*
 Values: 0 or 1
 Default: 0.
 

--- a/lib/nerdtree/tree_dir_node.vim
+++ b/lib/nerdtree/tree_dir_node.vim
@@ -466,7 +466,7 @@ function! s:TreeDirNode.refresh()
 
             " Regular expression is too expensive. Use simply string comparison
             " instead
-            if i[len(i)-3:2] != ".." && i[len(i)-2:2] != ".." && 
+            if i[len(i)-3:2] != ".." && i[len(i)-2:2] != ".." &&
              \ i[len(i)-2:1] != "." && i[len(i)-1] != "."
                 try
                     "create a new path and see if it exists in this nodes children

--- a/lib/nerdtree/tree_dir_node.vim
+++ b/lib/nerdtree/tree_dir_node.vim
@@ -250,6 +250,10 @@ endfunction
 "FUNCTION: TreeDirNode.isCascadable() {{{1
 "true if this dir has only one visible child - which is also a dir
 function! s:TreeDirNode.isCascadable()
+    if g:NERDTreeCascadeSingleChildDir == 0
+        return 0
+    endif
+
     let c = self.getVisibleChildren()
     return len(c) == 1 && c[0].path.isDirectory
 endfunction

--- a/lib/nerdtree/tree_dir_node.vim
+++ b/lib/nerdtree/tree_dir_node.vim
@@ -117,28 +117,14 @@ endfunction
 "FUNCTION: TreeDirNode.getCascade() {{{1
 "Return an array of dir nodes (starting from self) that can be cascade opened.
 function! s:TreeDirNode.getCascade()
+    if !self.isCascadable()
+        return [self]
+    endif
 
-    let rv = [self]
-    let node = self
+    let vc = self.getVisibleChildren()
+    let visChild = vc[0]
 
-    while 1
-        let vc = node.getVisibleChildren()
-        if len(vc) != 1
-            break
-        endif
-
-        let visChild = vc[0]
-
-        "TODO: optimize
-        if !visChild.path.isDirectory
-            break
-        endif
-
-        call add(rv, visChild)
-        let node = visChild
-    endwhile
-
-    return rv
+    return [self] + visChild.getCascade()
 endfunction
 
 "FUNCTION: TreeDirNode.getChildCount() {{{1

--- a/plugin/NERD_tree.vim
+++ b/plugin/NERD_tree.vim
@@ -74,6 +74,7 @@ else
     call s:initVariable("g:NERDTreeDirArrowCollapsible", "~")
 endif
 call s:initVariable("g:NERDTreeCascadeOpenSingleChildDir", 1)
+call s:initVariable("g:NERDTreeCascadeSingleChildDir", 1)
 
 if !exists("g:NERDTreeSortOrder")
     let g:NERDTreeSortOrder = ['\/$', '*', '\.swp$',  '\.bak$', '\~$']


### PR DESCRIPTION
This pull request adds the following option: `NERDTreeCascadeSingleChildDir`,
with default value of 1 (in order to keep the current behavior).

It can be disabled to prevent directory names from being collapsed into the same
line.

It doesn't affect the behavior of `NERDTreeCascadeOpenSingleChildDir`, because
it only changes how directories are displayed, not opened. Both options can be
used together in any combination.

After making the changes I realized "cascading" can generally be replaced with
"collapse", except when referring to "cascade open". I decided not to make this
change on this pull request.