### PR TITLE
Suppress autocmds less aggressively

### DIFF
--- a/autoload/nerdtree.vim
+++ b/autoload/nerdtree.vim
@@ -64,7 +64,7 @@ endfunction
 " same as :exec cmd  but eventignore=all is set for the duration
 function! nerdtree#exec(cmd)
     let old_ei = &ei
-    set ei=all
+    set ei=BufEnter,BufLeave,VimEnter
     exec a:cmd
     let &ei = old_ei
 endfunction


### PR DESCRIPTION
This is the counterpart to a PR I just submitted to undotree (https://github.com/mbbill/undotree/pull/61).

I noticed that my statusline doesn't update properly when using NERDTree to move between revisions of a file with `go` or `gi` (https://github.com/wincent/wincent/issues/16). I established that this was because it was using `'eventignore'` to suppress all autocmds, which in turn prevents the statusline from updating.

Commenting out the `set eventignore=all` line makes the failure to update go away, at the cost of firing more autocmds.

I considered adding an option for opting out of this behavior (eg. `let g:NERDTreeEventignore=0` or something), or rearchitecting my statusline to use an approach like vim-airline does based on CursorMoved autocmds (see https://github.com/vim-airline/vim-airline/issues/82; see also https://github.com/vim-airline/vim-airline/blob/30f078daf569e7d5e4f7829e39316387af349b41/plugin/airline.vim#L36-L50 for current implementation), but then realized that a simpler fix is to have NERDTree just disable only the autocmds that it uses instead of disabling all of them.

This is probably not enough to unbreak every bit of code in the world that depends on those autocmds, but it does at least unbreak my use case, because it allows my `WinLeave` autocmd to run and update the statusline.
