### PR TITLE
Expose initNerdTreeInPlace

### DIFF
--- a/autoload/nerdtree/ui_glue.vim
+++ b/autoload/nerdtree/ui_glue.vim
@@ -548,6 +548,7 @@ endfunction
 " FUNCTION: nerdtree#ui_glue#setupCommands() {{{1
 function! nerdtree#ui_glue#setupCommands()
     command! -n=? -complete=dir -bar NERDTree :call g:NERDTreeCreator.CreateTabTree('<args>')
+    command! -n=1 -complete=dir -bar NERDTreeInPlace :call s:initNerdTreeInPlace('<args>')
     command! -n=? -complete=dir -bar NERDTreeToggle :call g:NERDTreeCreator.ToggleTabTree('<args>')
     command! -n=0 -bar NERDTreeClose :call g:NERDTree.Close()
     command! -n=1 -complete=customlist,nerdtree#completeBookmarks -bar NERDTreeFromBookmark call g:NERDTreeCreator.CreateTabTree('<args>')


### PR DESCRIPTION
In need that to make NerdTree work with neovim's new TabNewEntered event.

My goal is to set the working directory any time a new tab is opened.

Unfortunately with NERDTreeHijackNetrw=1 things do not work as expected, so I had to set it to false, and then manually create a NERDTree window, like this:

``` vim

let g:NERDTreeHijackNetrw=0

function! OnTabEnter(path)
  if isdirectory(a:path)
    let dirname = a:path
    execute ":NERDTreeInPlace " . dirname
  else
    let dirname = fnamemodify(a:path, ":h")
  endif
  execute "tcd ". dirname
endfunction()

autocmd TabNewEntered * call OnTabEnter(expand("<amatch>"))
```

Note that I can't use plain old `:NERDTree` because it tould create a _new_ window
