### PR TITLE
Fix upward traversal when closing a cascade

### DIFF
--- a/autoload/nerdtree/ui_glue.vim
+++ b/autoload/nerdtree/ui_glue.vim
@@ -187,17 +187,17 @@ endfunction
 " closes the parent dir of the current node
 function! s:closeCurrentDir(node)
     let parent = a:node.parent
+    while g:NERDTreeCascadeOpenSingleChildDir && !parent.isRoot()
+        let childNodes = parent.getVisibleChildren()
+        if len(childNodes) == 1 && childNodes[0].path.isDirectory
+            let parent = parent.parent
+        else
+            break
+        endif
+    endwhile
     if parent ==# {} || parent.isRoot()
         call nerdtree#echo("cannot close tree root")
     else
-        while g:NERDTreeCascadeOpenSingleChildDir && !parent.parent.isRoot()
-            let childNodes = parent.getVisibleChildren()
-            if len(childNodes) == 1 && childNodes[0].path.isDirectory
-                let parent = parent.parent
-            else
-                break
-            endif
-        endwhile
         call parent.close()
         call b:NERDTree.render()
         call parent.putCursorHere(0, 0)

--- a/autoload/nerdtree/ui_glue.vim
+++ b/autoload/nerdtree/ui_glue.vim
@@ -191,8 +191,8 @@ function! s:closeCurrentDir(node)
         call nerdtree#echo("cannot close tree root")
     else
         while g:NERDTreeCascadeOpenSingleChildDir && !parent.parent.isRoot()
-            if parent.parent.getVisibleChildCount() == 1
-                call parent.close()
+            let childNodes = parent.getVisibleChildren()
+            if len(childNodes) == 1 && childNodes[0].path.isDirectory
                 let parent = parent.parent
             else
                 break


### PR DESCRIPTION
This is my fix for #519.

I noticed that `closeCurrentDir` was more "destructive" than a regular node toggle.
This was due to the "upward traversal" loop closing every parent and parent's parent and so on.

My change ensures that only a single node in a cascade is closed.
The appropriate node is found by traversing upwards.

The traversal stops when either happens:

* a node is found with more than 1 child
* a node if found with a child that is not a directory

That node becomes the `parent`, the loop `break`s and the regular closing process continues.