### PR TITLE
Use fnameescape to quote filenames for :badd.

### DIFF
--- a/nerdtree_plugin/fs_menu.vim
+++ b/nerdtree_plugin/fs_menu.vim
@@ -74,7 +74,7 @@ endfunction
 function! s:promptToRenameBuffer(bufnum, msg, newFileName)
     echo a:msg
     if g:NERDTreeAutoDeleteBuffer || nr2char(getchar()) ==# 'y'
-        let quotedFileName = "'" . a:newFileName . "'"
+        let quotedFileName = fnameescape(a:newFilename)
         " 1. ensure that a new buffer is loaded
         exec "badd " . quotedFileName
         " 2. ensure that all windows which display the just deleted filename


### PR DESCRIPTION
When you move a file in NERDTree's FS menu, and a buffer is already open with it, you're prompted to delete the old buffer and replace it with a new buffer pointing to the file's new location. This wasn't working correctly for me: because the new filename is passed to `badd` quoted with single quotes, Vim just created a new buffer pointing to a file called `'/Users/zack/.../filename'` _with_ the quotes. See the odd results of this when trying to rename a file in the nerdtree source tree:

<img width="1306" alt="screenshot 2016-06-30 16 20 00" src="https://cloud.githubusercontent.com/assets/55050/16507548/6f05fc6a-3edf-11e6-89d0-62bc19e69738.png">

This patch uses the `fnameescape()` function to do the filename escaping, rather than just surrounding with single quotes. I've tested it and it fixes the error seen in the above screenshot.