### PR TITLE
New option: NERDTreeShowExecutableFlag

### DIFF
--- a/doc/NERD_tree.txt
+++ b/doc/NERD_tree.txt
@@ -593,7 +593,9 @@ file explorers have.
 The script comes with two default menu plugins: exec_menuitem.vim and
 fs_menu.vim. fs_menu.vim adds some basic filesystem operations to the menu for
 creating/deleting/moving/copying files and dirs. exec_menuitem.vim provides a
-menu item to execute executable files.
+menu item to execute executable files. (By default, executable files are
+displayed with a trailing asterisk. This can be turned off by setting the
+|'NERDTreeShowExecutableFlag'| option to 0.)
 
 Related tags: |NERDTree-m| |NERDTreeApi|
 
@@ -654,6 +656,9 @@ NERD tree. These options should be set in your vimrc.
 |'NERDTreeShowHidden'|          Tells the NERD tree whether to display hidden
                                 files on startup.
 
+|'NERDTreeShowExecutableFlag'|  Tells the NERD tree whether to display the
+                                trailing '*' on executable files.
+
 |'NERDTreeShowLineNumbers'|     Tells the NERD tree whether to display line
                                 numbers in the tree window.
 
@@ -668,14 +673,14 @@ NERD tree. These options should be set in your vimrc.
 |'NERDTreeWinSize'|             Sets the window size when the NERD tree is
                                 opened.
 
-|'NERDTreeMinimalUI'|           Disables display of the 'Bookmarks' label and 
+|'NERDTreeMinimalUI'|           Disables display of the 'Bookmarks' label and
                                 'Press ? for help' text.
 
 |'NERDTreeCascadeOpenSingleChildDir'|
                                 Cascade open while selected directory has only
                                 one child that also is a directory.
 
-|'NERDTreeAutoDeleteBuffer'|    Tells the NERD tree to automatically remove 
+|'NERDTreeAutoDeleteBuffer'|    Tells the NERD tree to automatically remove
                                 a buffer when a file is being deleted or renamed
                                 via a context menu command.
 
@@ -896,6 +901,18 @@ can be dynamically toggled, per tree, with the |NERDTree-I| mapping.  Use one
 of the follow lines to set this option: >
     let NERDTreeShowHidden=0
     let NERDTreeShowHidden=1
+<
+
+------------------------------------------------------------------------------
+                                                *'NERDTreeShowExecutableFlag'*
+Values: 0 or 1.
+Default: 1.
+
+This option tells the NERD tree whether to display the trailing '*' on
+executable files. This option cannot be dynamically toggled. Use one of the
+following lines to set this option: >
+    let NERDTreeShowExecutableFlag=0
+    let NERDTreeShowExecutableFlag=1
 <
 
 ------------------------------------------------------------------------------

--- a/lib/nerdtree/path.vim
+++ b/lib/nerdtree/path.vim
@@ -42,7 +42,7 @@ endfunction
 function! s:Path.cacheDisplayString() abort
     let self.cachedDisplayString = self.getLastPathComponent(1)
 
-    if self.isExecutable
+    if self.isExecutable && g:NERDTreeShowExecutableFlag
         let self.cachedDisplayString = self.cachedDisplayString . '*'
     endif
 

--- a/plugin/NERD_tree.vim
+++ b/plugin/NERD_tree.vim
@@ -66,6 +66,7 @@ call s:initVariable("g:NERDTreeShowFiles", 1)
 call s:initVariable("g:NERDTreeShowHidden", 0)
 call s:initVariable("g:NERDTreeShowLineNumbers", 0)
 call s:initVariable("g:NERDTreeSortDirs", 1)
+call s:initVariable("g:NERDTreeShowExecutableFlag", 1)
 
 if !nerdtree#runningWindows()
     call s:initVariable("g:NERDTreeDirArrowExpandable", "▸")


### PR DESCRIPTION
This pull requests fixes #590. A new option `NERDTreeShowExecutableFlag` can be set to 0 in your .vimrc to prevent displaying the trailing asterisk of executable files.