### PR TITLE
Correct broken helptags command in docs.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -60,7 +60,7 @@ Installation
     cd ~/.vim/bundle
     git clone https://github.com/scrooloose/nerdtree.git
 
-Then reload vim, run `:helptags`, and check out `:help NERD_tree.txt`.
+Then reload vim, run `:helptags ~/.vim/bundle/nerdtree/doc/`, and check out `:help NERD_tree.txt`.
 
 
 ####[apt-vim](https://github.com/egalpin/apt-vim)


### PR DESCRIPTION
Currently, the documentation states:

Then reload vim, run `:helptags`, and check out `:help NERD_tree.txt`.

It turns out that `:helptags` is not a valid Vim command. I got the error

```
E471: Argument required
```

This experience is also described in this [StackOverflow post - Vim - helptags not working for NERDtree](http://stackoverflow.com/questions/9468914/vim-helptags-not-working-for-nerdtree).

I propose to change the README to say 

Then reload vim, run `:helptags ~/.vim/bundle/nerdtree/doc/`, and check out `:help NERD_tree.txt`.

This is the valid command that needs to be executed. This will help people install NERDTree, and avoid the installation frustration that I and many others experienced.
