### PR TITLE
Fix typo in argument usage in promptToRenameBuffer

### DIFF
--- a/nerdtree_plugin/fs_menu.vim
+++ b/nerdtree_plugin/fs_menu.vim
@@ -74,7 +74,7 @@ endfunction
 function! s:promptToRenameBuffer(bufnum, msg, newFileName)
     echo a:msg
     if g:NERDTreeAutoDeleteBuffer || nr2char(getchar()) ==# 'y'
-        let quotedFileName = fnameescape(a:newFilename)
+        let quotedFileName = fnameescape(a:newFileName)
         " 1. ensure that a new buffer is loaded
         exec "badd " . quotedFileName
         " 2. ensure that all windows which display the just deleted filename


### PR DESCRIPTION
Was seeing an issue where renaming a file and then reloading it would throw a pretty gnarly error. Tracked it down to this typo, which seems to fix it.

Related issue: https://github.com/scrooloose/nerdtree/issues/622
