### PR TITLE
Trick to open NERDTree as a tab window.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -100,10 +100,14 @@ Stick this in your vimrc:
 
 Note: Now start vim with plain `vim`, not `vim .`
 
-Or use the following directives if you prefer using `vim .`:
+
+---
+> How can I open NERDTree as a tab window automatically when vim opens a directory?
 
     autocmd StdinReadPre * let s:std_in=1
-    autocmd VimEnter * if argc() == 1 && argv()[0] == '.' && !exists("s:std_in") | NERDTree | wincmd p | ene | endif
+    autocmd VimEnter * if argc() == 1 && isdirectory(argv()[0]) && !exists("s:std_in") | NERDTree | wincmd p | ene | endif
+
+This trick also prevents NERDTree from hiding when first select a file.
 
 ---
 > How can I open NERDTree on startup, and have my cursor start in the other window?

--- a/README.markdown
+++ b/README.markdown
@@ -100,6 +100,11 @@ Stick this in your vimrc:
 
 Note: Now start vim with plain `vim`, not `vim .`
 
+Or use the following directives if you prefer using `vim .`:
+
+    autocmd StdinReadPre * let s:std_in=1
+    autocmd VimEnter * if argc() == 1 && argv()[0] == '.' && !exists("s:std_in") | NERDTree | wincmd p | ene | endif
+
 ---
 > How can I open NERDTree on startup, and have my cursor start in the other window?
 


### PR DESCRIPTION
Update README file, add directives to open NERDTree as a tab window automatically when vim starts up on opening a directory. Which can prevent NERDTree from hiding when first file selected as issue #494 pointed out.