### PR TITLE
Add note in README: trick to open NERDTree as a window on startup.

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -100,10 +100,14 @@ Stick this in your vimrc:
 
 Note: Now start vim with plain `vim`, not `vim .`
 
-Or use the following directives if you prefer using `vim .`:
+
+---
+> How can I open NERDTree as a tab window automatically when vim opens a directory?
 
     autocmd StdinReadPre * let s:std_in=1
-    autocmd VimEnter * if argc() == 1 && argv()[0] == '.' && !exists("s:std_in") | NERDTree | wincmd p | ene | endif
+    autocmd VimEnter * if argc() == 1 && isdirectory(argv()[0]) && !exists("s:std_in") | NERDTree | wincmd p | ene | endif
+
+This trick also prevents NERDTree from hiding when first select a file.
 
 ---
 > How can I open NERDTree on startup, and have my cursor start in the other window?

--- a/README.markdown
+++ b/README.markdown
@@ -100,6 +100,11 @@ Stick this in your vimrc:
 
 Note: Now start vim with plain `vim`, not `vim .`
 
+Or use the following directives if you prefer using `vim .`:
+
+    autocmd StdinReadPre * let s:std_in=1
+    autocmd VimEnter * if argc() == 1 && argv()[0] == '.' && !exists("s:std_in") | NERDTree | wincmd p | ene | endif
+
 ---
 > How can I open NERDTree on startup, and have my cursor start in the other window?
 

--- a/README.markdown
+++ b/README.markdown
@@ -102,23 +102,13 @@ Note: Now start vim with plain `vim`, not `vim .`
 
 
 ---
-> How can I open NERDTree as a tab window automatically when vim starts up on opening a directory?
+> How can I open NERDTree as a window automatically when vim starts up on opening a directory?
 
     autocmd StdinReadPre * let s:std_in=1
     autocmd VimEnter * if argc() == 1 && isdirectory(argv()[0]) && !exists("s:std_in") | exe 'NERDTree' argv()[0] | wincmd p | ene | endif
 
 This trick also prevents NERDTree from hiding when first select a file.
 
----
-> How can I open NERDTree on startup, and have my cursor start in the other window?
-
-Stick this in your vimrc:
-
-    autocmd vimenter * NERDTree
-    autocmd vimenter * wincmd p
-
- *via [stackoverflow/Yohann](http://stackoverflow.com/questions/4277808/nerdtree-auto-focus-to-file-when-opened-in-new-tab/19330023#19330023)*
- 
 ---
 > How can I map a specific key or shortcut to open NERDTree?
 

--- a/README.markdown
+++ b/README.markdown
@@ -102,10 +102,10 @@ Note: Now start vim with plain `vim`, not `vim .`
 
 
 ---
-> How can I open NERDTree as a tab window automatically when vim opens a directory?
+> How can I open NERDTree as a tab window automatically when vim starts up on opening a directory?
 
     autocmd StdinReadPre * let s:std_in=1
-    autocmd VimEnter * if argc() == 1 && isdirectory(argv()[0]) && !exists("s:std_in") | NERDTree | wincmd p | ene | endif
+    autocmd VimEnter * if argc() == 1 && isdirectory(argv()[0]) && !exists("s:std_in") | exe 'NERDTree' argv()[0] | wincmd p | ene | endif
 
 This trick also prevents NERDTree from hiding when first select a file.
 


### PR DESCRIPTION
Update README file, add directives to open NERDTree as a window automatically when vim starts up on opening a directory. Which can prevent NERDTree from hiding when first file selected as issue #494 pointed out.