### PR TITLE
fix bug with files and directories that have dollar sign in name

### DIFF
--- a/lib/nerdtree/path.vim
+++ b/lib/nerdtree/path.vim
@@ -301,10 +301,10 @@ endfunction
 "FUNCTION: Path._escChars() {{{1
 function! s:Path._escChars()
     if nerdtree#runningWindows()
-        return " `\|\"#%&,?()\*^<>"
+        return " `\|\"#%&,?()\*^<>$"
     endif
 
-    return " \\`\|\"#%&,?()\*^<>[]"
+    return " \\`\|\"#%&,?()\*^<>[]$"
 endfunction
 
 "FUNCTION: Path.getDir() {{{1


### PR DESCRIPTION
this is a fix for issue #420 which seems to be the better than the fix-hack proposed in that thread.