### PR TITLE
Update NERD_tree.vim

### DIFF
--- a/plugin/NERD_tree.vim
+++ b/plugin/NERD_tree.vim
@@ -204,8 +204,12 @@ function! NERDTreeFocus()
 endfunction
 
 function! NERDTreeCWD()
-    call NERDTreeFocus()
-    call nerdtree#ui_glue#chRootCwd()
+   if g:NERDTree.IsOpen()
+       call g:NERDTreeCreator.ToggleTabTree("")
+   else
+       call g:NERDTreeCreator.ToggleTabTree("")
+       call nerdtree#ui_glue#chRootCwd()
+   endif
 endfunction
 
 function! NERDTreeAddPathFilter(callback)


### PR DESCRIPTION
add toggle ability to NERDTreeCWD.
because NERDTreeToggle changes NERD root to current buffer only at first trigger, then the root will not change again after i change to another buffer, even i set a path argument when i call NERDTreeToggle.NERDTreeCWD does good at change root dir. so we can use NERDTreeCWD instead of NERDTreeToggle.