### PR TITLE
Use relative path with globpath

### DIFF
--- a/lib/nerdtree/tree_dir_node.vim
+++ b/lib/nerdtree/tree_dir_node.vim
@@ -272,7 +272,9 @@ function! s:TreeDirNode._initChildren(silent)
 
     "get an array of all the files in the nodes dir
     let dir = self.path
-    let globDir = dir.str({'format': 'Glob'})
+
+    "use a relative globDir so that relative wildignore rules will be obeyed
+    let globDir = fnamemodify(dir.str({'format': 'Glob'}), ':.')
 
     if version >= 703
         let filesStr = globpath(globDir, '*', !g:NERDTreeRespectWildIgnore) . "\n" . globpath(globDir, '.*', !g:NERDTreeRespectWildIgnore)
@@ -445,7 +447,7 @@ function! s:TreeDirNode.refresh()
         let newChildNodes = []
         let invalidFilesFound = 0
         let dir = self.path
-        let globDir = dir.str({'format': 'Glob'})
+        let globDir = fnamemodify(dir.str({'format': 'Glob'}), ':.')
         let filesStr = globpath(globDir, '*') . "\n" . globpath(globDir, '.*')
         let files = split(filesStr, "\n")
         for i in files


### PR DESCRIPTION
Wildignore rules that involve directories aren't handled properly (or at least as one might intuitively expect) when globpath uses absolute paths. For example, when the cwd is `/home/user/project` and wildignore contains `src/*.js`, `globpath("src", "*")` works as expected, while `globpath("/home/user/project/src", "*")` doesn't (js files aren't ignored).