### PR TITLE
Added back WinEnter and WinLeave to eventignore in nerdtree#exec(cmd)

### DIFF
--- a/autoload/nerdtree.vim
+++ b/autoload/nerdtree.vim
@@ -91,10 +91,10 @@ endfunction
 " FUNCTION: nerdtree#exec(cmd) {{{2
 " Same as :exec cmd but with eventignore set for the duration
 " to disable the autocommands used by NERDTree (BufEnter,
-" BufLeave and VimEnter)
+" BufLeave, VimEnter, WinEnter and WinLeave)
 function! nerdtree#exec(cmd)
     let old_ei = &ei
-    set ei=BufEnter,BufLeave,VimEnter
+    set ei=BufEnter,BufLeave,VimEnter,WinEnter,WinLeave
     exec a:cmd
     let &ei = old_ei
 endfunction


### PR DESCRIPTION
NERDTree relies on executing 'wincmd p' back and forth as part of its
normal operation.

This implementation detail is not obvious to NERDTree users that may
set up autocommands.

As such, it makes sense to ignore WinEnter and WinLeave autocmnds in
nerdtree#exec(cmd).