### PR TITLE
BUGFIX: Broken "g:NERDTreeBookmarksSort" setting fixed.

### DIFF
--- a/autoload/nerdtree.vim
+++ b/autoload/nerdtree.vim
@@ -52,11 +52,6 @@ function! nerdtree#completeBookmarks(A,L,P)
     return filter(g:NERDTreeBookmark.BookmarkNames(), 'v:val =~# "^' . a:A . '"')
 endfunction
 
-"FUNCTION: nerdtree#compareBookmarks(dir) {{{2
-function! nerdtree#compareBookmarks(first, second)
-    return a:first.compareTo(a:second)
-endfunction
-
 "FUNCTION: nerdtree#compareNodes(dir) {{{2
 function! nerdtree#compareNodes(n1, n2)
     return a:n1.path.compareTo(a:n2.path)

--- a/doc/NERD_tree.txt
+++ b/doc/NERD_tree.txt
@@ -835,11 +835,15 @@ This is where bookmarks are saved. See |NERDTreeBookmarkCommands|.
 
 ------------------------------------------------------------------------------
                                                      *'NERDTreeBookmarksSort'*
-Values: 0 or 1
+Values: 0, 1, or 2
 Default: 1
 
-If set to 0 then the bookmarks list is not sorted.
-If set to 1 the bookmarks list is sorted.
+This option controls the method by which the list of user bookmarks is
+sorted. When sorted, bookmarks will render in alphabetical order by name.
+
+If set to 0, the bookmarks list is not sorted.
+If set to 1, the bookmarks list is sorted in a case-insensitive manner.
+If set to 2, the bookmarks list is sorted in a case-sensitive manner.
 
 ------------------------------------------------------------------------------
                                                        *'NERDTreeMouseMode'*

--- a/lib/nerdtree/bookmark.vim
+++ b/lib/nerdtree/bookmark.vim
@@ -24,7 +24,7 @@ function! s:Bookmark.AddBookmark(name, path)
     endif
 endfunction
 
-" FUNCTION: Bookmark.Bookmarks()   {{{1
+" FUNCTION: Bookmark.Bookmarks() {{{1
 " Class method to get all bookmarks. Lazily initializes the bookmarks global
 " variable
 function! s:Bookmark.Bookmarks()
@@ -34,7 +34,7 @@ function! s:Bookmark.Bookmarks()
     return g:NERDTreeBookmarks
 endfunction
 
-" FUNCTION: Bookmark.BookmarkExistsFor(name)   {{{1
+" FUNCTION: Bookmark.BookmarkExistsFor(name) {{{1
 " class method that returns 1 if a bookmark with the given name is found, 0
 " otherwise
 function! s:Bookmark.BookmarkExistsFor(name)
@@ -46,7 +46,7 @@ function! s:Bookmark.BookmarkExistsFor(name)
     endtry
 endfunction
 
-" FUNCTION: Bookmark.BookmarkFor(name)   {{{1
+" FUNCTION: Bookmark.BookmarkFor(name) {{{1
 " Class method to get the bookmark that has the given name. {} is return if no
 " bookmark is found
 function! s:Bookmark.BookmarkFor(name)
@@ -58,7 +58,7 @@ function! s:Bookmark.BookmarkFor(name)
     throw "NERDTree.BookmarkNotFoundError: no bookmark found for name: \"". a:name  .'"'
 endfunction
 
-" FUNCTION: Bookmark.BookmarkNames()   {{{1
+" FUNCTION: Bookmark.BookmarkNames() {{{1
 " Class method to return an array of all bookmark names
 function! s:Bookmark.BookmarkNames()
     let names = []
@@ -170,7 +170,7 @@ function! s:Bookmark.GetSelected()
     return {}
 endfunction
 
-" FUNCTION: Bookmark.InvalidBookmarks()   {{{1
+" FUNCTION: Bookmark.InvalidBookmarks() {{{1
 " Class method to get all invalid bookmark strings read from the bookmarks
 " file
 function! s:Bookmark.InvalidBookmarks()
@@ -233,20 +233,20 @@ function! s:Bookmark.openInNewTab(options)
     call self.open(a:options)
 endfunction
 
-" FUNCTION: Bookmark.setPath(path)   {{{1
+" FUNCTION: Bookmark.setPath(path) {{{1
 " makes this bookmark point to the given path
 function! s:Bookmark.setPath(path)
     let self.path = a:path
 endfunction
 
-" FUNCTION: Bookmark.Sort()   {{{1
+" FUNCTION: Bookmark.Sort() {{{1
 " Class method that sorts all bookmarks
 function! s:Bookmark.Sort()
     let CompareFunc = function("nerdtree#compareBookmarks")
     call sort(s:Bookmark.Bookmarks(), CompareFunc)
 endfunction
 
-" FUNCTION: Bookmark.str()   {{{1
+" FUNCTION: Bookmark.str() {{{1
 " Get the string that should be rendered in the view for this bookmark
 function! s:Bookmark.str()
     let pathStrMaxLen = winwidth(g:NERDTree.GetWinNum()) - 4 - len(self.name)
@@ -292,7 +292,7 @@ function! s:Bookmark.validate()
     endif
 endfunction
 
-" FUNCTION: Bookmark.Write()   {{{1
+" FUNCTION: Bookmark.Write() {{{1
 " Class method to write all bookmarks to the bookmarks file
 function! s:Bookmark.Write()
     let bookmarkStrings = []

--- a/lib/nerdtree/bookmark.vim
+++ b/lib/nerdtree/bookmark.vim
@@ -19,7 +19,7 @@ function! s:Bookmark.AddBookmark(name, path)
         endif
     endfor
     call add(s:Bookmark.Bookmarks(), s:Bookmark.New(a:name, a:path))
-    if g:NERDTreeBookmarksSort ==# 1
+    if g:NERDTreeBookmarksSort == 1 || g:NERDTreeBookmarksSort == 2
         call s:Bookmark.SortBookmarksList()
     endif
 endfunction
@@ -104,17 +104,34 @@ function! s:Bookmark.CacheBookmarks(silent)
                 call nerdtree#echo(invalidBookmarksFound . " invalid bookmarks were read. See :help NERDTreeInvalidBookmarks for info.")
             endif
         endif
-        if g:NERDTreeBookmarksSort ==# 1
+        if g:NERDTreeBookmarksSort == 1 || g:NERDTreeBookmarksSort == 2
             call s:Bookmark.SortBookmarksList()
         endif
     endif
 endfunction
 
-" FUNCTION: Bookmark.compareTo(otherbookmark) {{{1
-" Compare these two bookmarks for sorting purposes
-function! s:Bookmark.compareTo(otherbookmark)
-    return a:otherbookmark.name < self.name
+" FUNCTION: Bookmark.CompareBookmarksByName(firstBookmark, secondBookmark) {{{1
+" Class method that indicates the relative position of two bookmarks when
+" placed in alphabetical order by name. Case-sensitivity is determined by an
+" option. Supports the "s:Bookmark.SortBookmarksList()" method.
+function! s:Bookmark.CompareBookmarksByName(firstBookmark, secondBookmark)
+    let l:result = 0
+    if g:NERDTreeBookmarksSort == 1
+        if a:firstBookmark.name <? a:secondBookmark.name
+            let l:result = -1
+        elseif a:firstBookmark.name >? a:secondBookmark.name
+            let l:result = 1
+        endif
+    elseif g:NERDTreeBookmarksSort == 2
+        if a:firstBookmark.name <# a:secondBookmark.name
+            let l:result = -1
+        elseif a:firstBookmark.name ># a:secondBookmark.name
+            let l:result = 1
+        endif
+    endif
+    return l:result
 endfunction
+
 " FUNCTION: Bookmark.ClearAll() {{{1
 " Class method to delete all bookmarks.
 function! s:Bookmark.ClearAll()
@@ -240,10 +257,10 @@ function! s:Bookmark.setPath(path)
 endfunction
 
 " FUNCTION: Bookmark.SortBookmarksList() {{{1
-" Class method that sorts the global list of bookmarks by name.
+" Class method that sorts the global list of bookmarks alphabetically by name.
+" Note that case-sensitivity is determined by a user option.
 function! s:Bookmark.SortBookmarksList()
-    let CompareFunc = function("nerdtree#compareBookmarks")
-    call sort(s:Bookmark.Bookmarks(), CompareFunc)
+    call sort(s:Bookmark.Bookmarks(), s:Bookmark.CompareBookmarksByName)
 endfunction
 
 " FUNCTION: Bookmark.str() {{{1

--- a/lib/nerdtree/bookmark.vim
+++ b/lib/nerdtree/bookmark.vim
@@ -19,9 +19,6 @@ function! s:Bookmark.AddBookmark(name, path)
         endif
     endfor
     call add(s:Bookmark.Bookmarks(), s:Bookmark.New(a:name, a:path))
-    if g:NERDTreeBookmarksSort == 1 || g:NERDTreeBookmarksSort == 2
-        call s:Bookmark.SortBookmarksList()
-    endif
 endfunction
 
 " FUNCTION: Bookmark.Bookmarks() {{{1
@@ -103,9 +100,6 @@ function! s:Bookmark.CacheBookmarks(silent)
             if !a:silent
                 call nerdtree#echo(invalidBookmarksFound . " invalid bookmarks were read. See :help NERDTreeInvalidBookmarks for info.")
             endif
-        endif
-        if g:NERDTreeBookmarksSort == 1 || g:NERDTreeBookmarksSort == 2
-            call s:Bookmark.SortBookmarksList()
         endif
     endif
 endfunction

--- a/lib/nerdtree/bookmark.vim
+++ b/lib/nerdtree/bookmark.vim
@@ -20,7 +20,7 @@ function! s:Bookmark.AddBookmark(name, path)
     endfor
     call add(s:Bookmark.Bookmarks(), s:Bookmark.New(a:name, a:path))
     if g:NERDTreeBookmarksSort ==# 1
-        call s:Bookmark.Sort()
+        call s:Bookmark.SortBookmarksList()
     endif
 endfunction
 
@@ -105,7 +105,7 @@ function! s:Bookmark.CacheBookmarks(silent)
             endif
         endif
         if g:NERDTreeBookmarksSort ==# 1
-            call s:Bookmark.Sort()
+            call s:Bookmark.SortBookmarksList()
         endif
     endif
 endfunction
@@ -239,9 +239,9 @@ function! s:Bookmark.setPath(path)
     let self.path = a:path
 endfunction
 
-" FUNCTION: Bookmark.Sort() {{{1
-" Class method that sorts all bookmarks
-function! s:Bookmark.Sort()
+" FUNCTION: Bookmark.SortBookmarksList() {{{1
+" Class method that sorts the global list of bookmarks by name.
+function! s:Bookmark.SortBookmarksList()
     let CompareFunc = function("nerdtree#compareBookmarks")
     call sort(s:Bookmark.Bookmarks(), CompareFunc)
 endfunction

--- a/lib/nerdtree/ui.vim
+++ b/lib/nerdtree/ui.vim
@@ -313,6 +313,10 @@ function! s:UI._renderBookmarks()
         call cursor(line(".")+1, col("."))
     endif
 
+    if g:NERDTreeBookmarksSort == 1 || g:NERDTreeBookmarksSort == 2
+        call g:NERDTreeBookmark.SortBookmarksList()
+    endif
+
     for i in g:NERDTreeBookmark.Bookmarks()
         call setline(line(".")+1, i.str())
         call cursor(line(".")+1, col("."))


### PR DESCRIPTION
The feature that is supposed to allow users' bookmarks to be sorted doesn't currently work and appears to never have actually worked. I put together this PR to address this issue.

The commit messages are well-written and thoroughly describe the changes that were made.

See issue #361.

Thanks!