### PR TITLE
BUGFIX: Repair the broken ":OpenBookmark" command

### DIFF
--- a/autoload/nerdtree/ui_glue.vim
+++ b/autoload/nerdtree/ui_glue.vim
@@ -441,21 +441,19 @@ function! s:jumpToSibling(currentNode, forward)
 endfunction
 
 " FUNCTION: nerdtree#ui_glue#openBookmark(name) {{{1
-" put the cursor on the given bookmark and, if its a file, open it
+" Open the Bookmark that has the specified name. This function provides the
+" implementation for the ":OpenBookmark" command.
 function! nerdtree#ui_glue#openBookmark(name)
     try
-        let targetNode = g:NERDTreeBookmark.GetNodeForName(a:name, 0, b:NERDTree)
-        call targetNode.putCursorHere(0, 1)
-        redraw!
-    catch /^NERDTree.BookmarkedNodeNotFoundError/
-        call nerdtree#echo("note - target node is not cached")
-        let bookmark = g:NERDTreeBookmark.BookmarkFor(a:name)
-        let targetNode = g:NERDTreeFileNode.New(bookmark.path, b:NERDTree)
+        let l:bookmark = g:NERDTreeBookmark.BookmarkFor(a:name)
+    catch /^NERDTree.BookmarkNotFoundError/
+        call nerdtree#echoError('bookmark "' . a:name . '" not found')
+        return
     endtry
-    if targetNode.path.isDirectory
-        call targetNode.openExplorer()
+    if l:bookmark.path.isDirectory
+        call l:bookmark.open(b:NERDTree)
     else
-        call targetNode.open({'where': 'p'})
+        call l:bookmark.open(b:NERDTree, {'where': 'p'})
     endif
 endfunction
 

--- a/doc/NERD_tree.txt
+++ b/doc/NERD_tree.txt
@@ -158,7 +158,7 @@ click bookmarks or use the |NERDTree-o| mapping to activate them. See also,
 ------------------------------------------------------------------------------
 2.2.2. Bookmark commands                            *NERDTreeBookmarkCommands*
 
-Note that the following commands are only available in the NERD tree buffer.
+Note: The following commands are only available within the NERDTree buffer.
 
 :Bookmark [<name>]
     Bookmark the current node as <name>. If there is already a <name>
@@ -178,10 +178,11 @@ Note that the following commands are only available in the NERD tree buffer.
     (i.e. directory nodes above it will be opened) and the cursor will be
     placed on it.
 
-:OpenBookmark <bookmark>
-    <bookmark> must point to a file. The file is opened as though |NERDTree-o|
-    was applied. If the node is cached under the current root then it will be
-    revealed and the cursor will be placed on it.
+:OpenBookmark <name>
+    The Bookmark named <name> is opened as if |NERDTree-o| was applied to
+    its entry in the Bookmark table. If the Bookmark points to a directory,
+    it is made the new root of the current NERDTree. If the Bookmark points
+    to a file, that file is opened for editing in another window.
 
 :ClearBookmarks [<bookmarks>]
     Remove all the given bookmarks. If no bookmarks are given then remove all

--- a/lib/nerdtree/bookmark.vim
+++ b/lib/nerdtree/bookmark.vim
@@ -44,15 +44,20 @@ function! s:Bookmark.BookmarkExistsFor(name)
 endfunction
 
 " FUNCTION: Bookmark.BookmarkFor(name) {{{1
-" Class method to get the bookmark that has the given name. {} is return if no
-" bookmark is found
+" Class method that returns the Bookmark object having the specified name.
+" Throws "NERDTree.BookmarkNotFoundError" if no Bookmark is found.
 function! s:Bookmark.BookmarkFor(name)
-    for i in s:Bookmark.Bookmarks()
-        if i.name ==# a:name
-            return i
+    let l:result = {}
+    for l:bookmark in s:Bookmark.Bookmarks()
+        if l:bookmark.name ==# a:name
+            let l:result = l:bookmark
+            break
         endif
     endfor
-    throw "NERDTree.BookmarkNotFoundError: no bookmark found for name: \"". a:name  .'"'
+    if empty(l:result)
+        throw 'NERDTree.BookmarkNotFoundError: "' . a:name  . '" not found'
+    endif
+    return l:result
 endfunction
 
 " FUNCTION: Bookmark.BookmarkNames() {{{1

--- a/lib/nerdtree/bookmark.vim
+++ b/lib/nerdtree/bookmark.vim
@@ -172,11 +172,13 @@ function! s:Bookmark.getNode(nerdtree, searchFromAbsoluteRoot)
 endfunction
 
 " FUNCTION: Bookmark.GetNodeForName(name, searchFromAbsoluteRoot, nerdtree) {{{1
-" Class method that finds the bookmark with the given name and returns the
-" treenode for it.
+" Class method that returns the tree node object for the Bookmark with the
+" given name. Throws "NERDTree.BookmarkNotFoundError" if a Bookmark with the
+" name does not exist. Throws "NERDTree.BookmarkedNodeNotFoundError" if a
+" tree node for the named Bookmark could not be found.
 function! s:Bookmark.GetNodeForName(name, searchFromAbsoluteRoot, nerdtree)
-    let bookmark = s:Bookmark.BookmarkFor(a:name)
-    return bookmark.getNode(nerdtree, a:searchFromAbsoluteRoot)
+    let l:bookmark = s:Bookmark.BookmarkFor(a:name)
+    return l:bookmark.getNode(a:nerdtree, a:searchFromAbsoluteRoot)
 endfunction
 
 " FUNCTION: Bookmark.GetSelected() {{{1

--- a/lib/nerdtree/bookmark.vim
+++ b/lib/nerdtree/bookmark.vim
@@ -1,5 +1,13 @@
-"CLASS: Bookmark
-"============================================================
+" ============================================================================
+" CLASS: Bookmark
+"
+" The Bookmark class serves two purposes:
+"   (1) It is the top-level prototype for new, concrete Bookmark objects.
+"   (2) It provides an interface for client code to query and manipulate the
+"       global list of Bookmark objects within the current Vim session.
+" ============================================================================
+
+
 let s:Bookmark = {}
 let g:NERDTreeBookmark = s:Bookmark
 

--- a/lib/nerdtree/bookmark.vim
+++ b/lib/nerdtree/bookmark.vim
@@ -157,18 +157,23 @@ function! s:Bookmark.delete()
 endfunction
 
 " FUNCTION: Bookmark.getNode(nerdtree, searchFromAbsoluteRoot) {{{1
-" Gets the treenode for this bookmark
+" Returns the tree node object associated with this Bookmark.
+" Throws "NERDTree.BookmarkedNodeNotFoundError" if the node is not found.
 "
 " Args:
-" searchFromAbsoluteRoot: specifies whether we should search from the current
-" tree root, or the highest cached node
+" searchFromAbsoluteRoot: boolean flag, search from the highest cached node
+"   if true and from the current tree root if false
 function! s:Bookmark.getNode(nerdtree, searchFromAbsoluteRoot)
-    let searchRoot = a:searchFromAbsoluteRoot ? a:nerdtree.root.AbsoluteTreeRoot() : a:nerdtree.root
-    let targetNode = searchRoot.findNode(self.path)
-    if empty(targetNode)
-        throw "NERDTree.BookmarkedNodeNotFoundError: no node was found for bookmark: " . self.name
+    if a:searchFromAbsoluteRoot
+        let l:searchRoot = a:nerdtree.root.AbsoluteTreeRoot()
+    else
+        let l:searchRoot = a:nerdtree.root
     endif
-    return targetNode
+    let l:targetNode = l:searchRoot.findNode(self.path)
+    if empty(l:targetNode)
+        throw 'NERDTree.BookmarkedNodeNotFoundError: node for bookmark "' . self.name . '" not found'
+    endif
+    return l:targetNode
 endfunction
 
 " FUNCTION: Bookmark.GetNodeForName(name, searchFromAbsoluteRoot, nerdtree) {{{1

--- a/lib/nerdtree/creator.vim
+++ b/lib/nerdtree/creator.vim
@@ -14,7 +14,7 @@ function! s:Creator._bindMappings()
 
     command! -buffer -nargs=? Bookmark :call nerdtree#ui_glue#bookmarkNode('<args>')
     command! -buffer -complete=customlist,nerdtree#completeBookmarks -nargs=1 RevealBookmark :call nerdtree#ui_glue#revealBookmark('<args>')
-    command! -buffer -complete=customlist,nerdtree#completeBookmarks -nargs=1 OpenBookmark :call nerdtree#ui_glue#openBookmark('<args>')
+    command! -buffer -complete=customlist,nerdtree#completeBookmarks -nargs=1 OpenBookmark call nerdtree#ui_glue#openBookmark('<args>')
     command! -buffer -complete=customlist,nerdtree#completeBookmarks -nargs=* ClearBookmarks call nerdtree#ui_glue#clearBookmarks('<args>')
     command! -buffer -complete=customlist,nerdtree#completeBookmarks -nargs=+ BookmarkToRoot call g:NERDTreeBookmark.ToRoot('<args>', b:NERDTree)
     command! -buffer -nargs=0 ClearAllBookmarks call g:NERDTreeBookmark.ClearAll() <bar> call b:NERDTree.render()


### PR DESCRIPTION
Issue #677 pointed out that several Bookmark commands were  broken by a minor syntax error. The `:OpenBookmark` command was the most obvious among these (which can be used to replicate the error in issue #677). But others included...

`:RevealBookmark`
`:Bookmark` (users couldn't overwrite a Bookmark as the documentation promised)

The latter command was fixed as a side-effect of this PR. The first command is still unstable. The primary purpose of this PR was to fix `:OpenBookmark`, which was accomplished.