### PR TITLE
Updates FAQ for opening vim on directory

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -104,7 +104,7 @@ Note: Now start vim with plain `vim`, not `vim .`
 > How can I open NERDTree automatically when vim starts up on opening a directory?
 
     autocmd StdinReadPre * let s:std_in=1
-    autocmd VimEnter * if argc() == 1 && isdirectory(argv()[0]) && !exists("s:std_in") | exe 'NERDTree' argv()[0] | wincmd p | ene | endif
+    autocmd VimEnter * if argc() == 1 && isdirectory(argv()[0]) && !exists("s:std_in") | wincmd p | ene | exe 'NERDTree' argv()[0] | endif
 
 This window is tab-specific, meaning it's used by all windows in the tab. This trick also prevents NERDTree from hiding when first selecting a file.
 


### PR DESCRIPTION
Rearranges the command used to open NERDTree automatically when vim starts up on opening a directory. Now the command will set focus upon opening to the NERDTree split.