### PR TITLE
Modify call to sort() for older versions of Vim

### DIFF
--- a/lib/nerdtree/bookmark.vim
+++ b/lib/nerdtree/bookmark.vim
@@ -274,7 +274,7 @@ endfunction
 " Class method that sorts the global list of bookmarks alphabetically by name.
 " Note that case-sensitivity is determined by a user option.
 function! s:Bookmark.SortBookmarksList()
-    call sort(s:Bookmark.Bookmarks(), s:Bookmark.CompareBookmarksByName)
+    call sort(s:Bookmark.Bookmarks(), s:Bookmark.CompareBookmarksByName, s:Bookmark)
 endfunction
 
 " FUNCTION: Bookmark.str() {{{1


### PR DESCRIPTION
Older Vim versions seem to require that calls to sort() specify a
dictionary when the compare function argument is a dictionary
function. This seems to be required even when the dictionary is not
used. Since this change does not seem to affect behavior in later
Vim editions, I see no harm in including it.