### PR TITLE
Refactor TreeDirNode methods

### DIFF
--- a/lib/nerdtree/tree_dir_node.vim
+++ b/lib/nerdtree/tree_dir_node.vim
@@ -206,23 +206,27 @@ function! s:TreeDirNode.getDirChildren()
     return filter(self.children, 'v:val.path.isDirectory == 1')
 endfunction
 
-"FUNCTION: TreeDirNode._getGlobDir() {{{1
-"Return a string giving the pathname related to this TreeDirNode. The returned
-"pathname is in a glob-friendly format and is relative to the current working
-"directory, if this TreeDirNode's path is under the current working directory.
+" FUNCTION: TreeDirNode._getGlobDir() {{{1
+" Return a path specification for this TreeDirNode that is suitable as an
+" argument to "globpath()".
+"
+" Note: The result is constructed such that "globpath()" will return paths
+" relative to the working directory, if possible. This is necessary to ensure
+" that 'wildignore' rules for relative paths are obeyed.
 function! s:TreeDirNode._getGlobDir()
-    " Gets a relative path, if possible. This ensures that 'wildignore' rules
-    " for relative paths will be obeyed.
-    let l:globDir = fnamemodify(self.path.str({'format': 'Glob'}), ':.')
 
-    " Calling fnamemodify() with ':.' on Windows systems strips the leading
-    " drive letter from paths that aren't under the working directory. Here,
-    " the drive letter is added back to the pathname.
-    if nerdtree#runningWindows() && l:globDir[0] == '\'
-        let l:globDir = self.path.drive . l:globDir
+    if self.path.str() == getcwd()
+        let l:pathSpec = ','
+    else
+        let l:pathSpec = fnamemodify(self.path.str({'format': 'Glob'}), ':.')
+
+        " On Windows, the drive letter may be removed by "fnamemodify()".
+        if nerdtree#runningWindows() && l:pathSpec[0] == '\'
+            let l:pathSpec = self.path.drive . l:pathSpec
+        endif
     endif
 
-    return l:globDir
+    return l:pathSpec
 endfunction
 
 "FUNCTION: TreeDirNode.GetSelected() {{{1

--- a/lib/nerdtree/tree_dir_node.vim
+++ b/lib/nerdtree/tree_dir_node.vim
@@ -256,7 +256,6 @@ function! s:TreeDirNode._glob(pattern, all)
 
     " If "a:all" is false, filter "." and ".." from the output.
     if !a:all
-
         let l:toRemove = []
 
         for l:file in l:globList
@@ -275,10 +274,9 @@ function! s:TreeDirNode._glob(pattern, all)
             endif
         endfor
 
-        if !empty(l:toRemove)
-            call remove(l:globList, index(l:globList, l:toRemove[0]))
-            call remove(l:globList, index(l:globList, l:toRemove[1]))
-        endif
+        for l:file in l:toRemove
+            call remove(l:globList, index(l:globList, l:file))
+        endfor
     endif
 
     return l:globList

--- a/lib/nerdtree/tree_dir_node.vim
+++ b/lib/nerdtree/tree_dir_node.vim
@@ -1,13 +1,17 @@
-"CLASS: TreeDirNode
-"A subclass of NERDTreeFileNode.
+" ============================================================================
+" CLASS: TreeDirNode
 "
-"The 'composite' part of the file/dir composite.
-"============================================================
+" A subclass of NERDTreeFileNode.
+"
+" The 'composite' part of the file/dir composite.
+" ============================================================================
+
+
 let s:TreeDirNode = copy(g:NERDTreeFileNode)
 let g:NERDTreeDirNode = s:TreeDirNode
 
-"FUNCTION: TreeDirNode.AbsoluteTreeRoot(){{{1
-"class method that returns the highest cached ancestor of the current root
+" FUNCTION: TreeDirNode.AbsoluteTreeRoot(){{{1
+" Class method that returns the highest cached ancestor of the current root.
 function! s:TreeDirNode.AbsoluteTreeRoot()
     let currentNode = b:NERDTree.root
     while currentNode.parent != {}
@@ -16,7 +20,7 @@ function! s:TreeDirNode.AbsoluteTreeRoot()
     return currentNode
 endfunction
 
-"FUNCTION: TreeDirNode.activate([options]) {{{1
+" FUNCTION: TreeDirNode.activate([options]) {{{1
 unlet s:TreeDirNode.activate
 function! s:TreeDirNode.activate(...)
     let opts = a:0 ? a:1 : {}
@@ -25,12 +29,12 @@ function! s:TreeDirNode.activate(...)
     call self.putCursorHere(0, 0)
 endfunction
 
-"FUNCTION: TreeDirNode.addChild(treenode, inOrder) {{{1
-"Adds the given treenode to the list of children for this node
+" FUNCTION: TreeDirNode.addChild(treenode, inOrder) {{{1
+" Adds the given treenode to the list of children for this node
 "
-"Args:
-"-treenode: the node to add
-"-inOrder: 1 if the new node should be inserted in sorted order
+" Args:
+" -treenode: the node to add
+" -inOrder: 1 if the new node should be inserted in sorted order
 function! s:TreeDirNode.addChild(treenode, inOrder)
     call add(self.children, a:treenode)
     let a:treenode.parent = self
@@ -40,14 +44,14 @@ function! s:TreeDirNode.addChild(treenode, inOrder)
     endif
 endfunction
 
-"FUNCTION: TreeDirNode.close() {{{1
-"Closes this directory
+" FUNCTION: TreeDirNode.close() {{{1
+" Closes this directory
 function! s:TreeDirNode.close()
     let self.isOpen = 0
 endfunction
 
-"FUNCTION: TreeDirNode.closeChildren() {{{1
-"Closes all the child dir nodes of this node
+" FUNCTION: TreeDirNode.closeChildren() {{{1
+" Closes all the child dir nodes of this node
 function! s:TreeDirNode.closeChildren()
     for i in self.children
         if i.path.isDirectory
@@ -57,23 +61,23 @@ function! s:TreeDirNode.closeChildren()
     endfor
 endfunction
 
-"FUNCTION: TreeDirNode.createChild(path, inOrder) {{{1
-"Instantiates a new child node for this node with the given path. The new
-"nodes parent is set to this node.
+" FUNCTION: TreeDirNode.createChild(path, inOrder) {{{1
+" Instantiates a new child node for this node with the given path. The new
+" nodes parent is set to this node.
 "
-"Args:
-"path: a Path object that this node will represent/contain
-"inOrder: 1 if the new node should be inserted in sorted order
+" Args:
+" path: a Path object that this node will represent/contain
+" inOrder: 1 if the new node should be inserted in sorted order
 "
-"Returns:
-"the newly created node
+" Returns:
+" the newly created node
 function! s:TreeDirNode.createChild(path, inOrder)
     let newTreeNode = g:NERDTreeFileNode.New(a:path, self.getNerdtree())
     call self.addChild(newTreeNode, a:inOrder)
     return newTreeNode
 endfunction
 
-"FUNCTION: TreeDirNode.displayString() {{{1
+" FUNCTION: TreeDirNode.displayString() {{{1
 unlet s:TreeDirNode.displayString
 function! s:TreeDirNode.displayString()
     let cascade = self.getCascade()
@@ -89,11 +93,11 @@ function! s:TreeDirNode.displayString()
     return sym . ' ' . flags . rv
 endfunction
 
-"FUNCTION: TreeDirNode.findNode(path) {{{1
-"Will find one of the children (recursively) that has the given path
+" FUNCTION: TreeDirNode.findNode(path) {{{1
+" Will find one of the children (recursively) that has the given path
 "
-"Args:
-"path: a path object
+" Args:
+" path: a path object
 unlet s:TreeDirNode.findNode
 function! s:TreeDirNode.findNode(path)
     if a:path.equals(self.path)
@@ -114,8 +118,8 @@ function! s:TreeDirNode.findNode(path)
     return {}
 endfunction
 
-"FUNCTION: TreeDirNode.getCascade() {{{1
-"Return an array of dir nodes (starting from self) that can be cascade opened.
+" FUNCTION: TreeDirNode.getCascade() {{{1
+" Return an array of dir nodes (starting from self) that can be cascade opened.
 function! s:TreeDirNode.getCascade()
     if !self.isCascadable()
         return [self]
@@ -127,20 +131,20 @@ function! s:TreeDirNode.getCascade()
     return [self] + visChild.getCascade()
 endfunction
 
-"FUNCTION: TreeDirNode.getChildCount() {{{1
-"Returns the number of children this node has
+" FUNCTION: TreeDirNode.getChildCount() {{{1
+" Returns the number of children this node has
 function! s:TreeDirNode.getChildCount()
     return len(self.children)
 endfunction
 
-"FUNCTION: TreeDirNode.getChild(path) {{{1
-"Returns child node of this node that has the given path or {} if no such node
-"exists.
+" FUNCTION: TreeDirNode.getChild(path) {{{1
+" Returns child node of this node that has the given path or {} if no such node
+" exists.
 "
-"This function doesnt not recurse into child dir nodes
+" This function doesnt not recurse into child dir nodes
 "
-"Args:
-"path: a path object
+" Args:
+" path: a path object
 function! s:TreeDirNode.getChild(path)
     if stridx(a:path.str(), self.path.str(), 0) ==# -1
         return {}
@@ -155,12 +159,13 @@ function! s:TreeDirNode.getChild(path)
 
 endfunction
 
-"FUNCTION: TreeDirNode.getChildByIndex(indx, visible) {{{1
-"returns the child at the given index
-"Args:
-"indx: the index to get the child from
-"visible: 1 if only the visible children array should be used, 0 if all the
-"children should be searched.
+" FUNCTION: TreeDirNode.getChildByIndex(indx, visible) {{{1
+" returns the child at the given index
+"
+" Args:
+" indx: the index to get the child from
+" visible: 1 if only the visible children array should be used, 0 if all the
+" children should be searched.
 function! s:TreeDirNode.getChildByIndex(indx, visible)
     let array_to_search = a:visible? self.getVisibleChildren() : self.children
     if a:indx > len(array_to_search)
@@ -169,14 +174,14 @@ function! s:TreeDirNode.getChildByIndex(indx, visible)
     return array_to_search[a:indx]
 endfunction
 
-"FUNCTION: TreeDirNode.getChildIndex(path) {{{1
-"Returns the index of the child node of this node that has the given path or
-"-1 if no such node exists.
+" FUNCTION: TreeDirNode.getChildIndex(path) {{{1
+" Returns the index of the child node of this node that has the given path or
+" -1 if no such node exists.
 "
-"This function doesnt not recurse into child dir nodes
+" This function doesnt not recurse into child dir nodes
 "
-"Args:
-"path: a path object
+" Args:
+" path: a path object
 function! s:TreeDirNode.getChildIndex(path)
     if stridx(a:path.str(), self.path.str(), 0) ==# -1
         return -1
@@ -200,8 +205,9 @@ function! s:TreeDirNode.getChildIndex(path)
     return -1
 endfunction
 
-"FUNCTION: TreeDirNode.getDirChildren() {{{1
-"Get all children that are directories
+" FUNCTION: TreeDirNode.getDirChildren() {{{1
+" Return a list of all child nodes from "self.children" that are of type
+" TreeDirNode.
 function! s:TreeDirNode.getDirChildren()
     return filter(self.children, 'v:val.path.isDirectory == 1')
 endfunction
@@ -278,9 +284,9 @@ function! s:TreeDirNode._glob(pattern, all)
     return l:globList
 endfunction
 
-"FUNCTION: TreeDirNode.GetSelected() {{{1
-"Returns the current node if it is a dir node, or else returns the current
-"nodes parent
+" FUNCTION: TreeDirNode.GetSelected() {{{1
+" Returns the current node if it is a dir node, or else returns the current
+" nodes parent
 unlet s:TreeDirNode.GetSelected
 function! s:TreeDirNode.GetSelected()
     let currentDir = g:NERDTreeFileNode.GetSelected()
@@ -292,17 +298,17 @@ function! s:TreeDirNode.GetSelected()
     return currentDir
 endfunction
 
-"FUNCTION: TreeDirNode.getVisibleChildCount() {{{1
-"Returns the number of visible children this node has
+" FUNCTION: TreeDirNode.getVisibleChildCount() {{{1
+" Returns the number of visible children this node has
 function! s:TreeDirNode.getVisibleChildCount()
     return len(self.getVisibleChildren())
 endfunction
 
-"FUNCTION: TreeDirNode.getVisibleChildren() {{{1
-"Returns a list of children to display for this node, in the correct order
+" FUNCTION: TreeDirNode.getVisibleChildren() {{{1
+" Returns a list of children to display for this node, in the correct order
 "
-"Return:
-"an array of treenodes
+" Return:
+" an array of treenodes
 function! s:TreeDirNode.getVisibleChildren()
     let toReturn = []
     for i in self.children
@@ -313,14 +319,14 @@ function! s:TreeDirNode.getVisibleChildren()
     return toReturn
 endfunction
 
-"FUNCTION: TreeDirNode.hasVisibleChildren() {{{1
-"returns 1 if this node has any childre, 0 otherwise..
+" FUNCTION: TreeDirNode.hasVisibleChildren() {{{1
+" returns 1 if this node has any childre, 0 otherwise..
 function! s:TreeDirNode.hasVisibleChildren()
     return self.getVisibleChildCount() != 0
 endfunction
 
-"FUNCTION: TreeDirNode.isCascadable() {{{1
-"true if this dir has only one visible child - which is also a dir
+" FUNCTION: TreeDirNode.isCascadable() {{{1
+" true if this dir has only one visible child - which is also a dir
 function! s:TreeDirNode.isCascadable()
     if g:NERDTreeCascadeSingleChildDir == 0
         return 0
@@ -330,14 +336,14 @@ function! s:TreeDirNode.isCascadable()
     return len(c) == 1 && c[0].path.isDirectory
 endfunction
 
-"FUNCTION: TreeDirNode._initChildren() {{{1
-"Removes all childen from this node and re-reads them
+" FUNCTION: TreeDirNode._initChildren() {{{1
+" Removes all childen from this node and re-reads them
 "
-"Args:
-"silent: 1 if the function should not echo any "please wait" messages for
-"large directories
+" Args:
+" silent: 1 if the function should not echo any "please wait" messages for
+" large directories
 "
-"Return: the number of child nodes read
+" Return: the number of child nodes read
 function! s:TreeDirNode._initChildren(silent)
     "remove all the current child nodes
     let self.children = []
@@ -371,12 +377,12 @@ function! s:TreeDirNode._initChildren(silent)
     return self.getChildCount()
 endfunction
 
-"FUNCTION: TreeDirNode.New(path, nerdtree) {{{1
-"Returns a new TreeNode object with the given path and parent
+" FUNCTION: TreeDirNode.New(path, nerdtree) {{{1
+" Return a new TreeDirNode object with the given path and parent.
 "
-"Args:
-"path: dir that the node represents
-"nerdtree: the tree the node belongs to
+" Args:
+" path: dir that the node represents
+" nerdtree: the tree the node belongs to
 function! s:TreeDirNode.New(path, nerdtree)
     if a:path.isDirectory != 1
         throw "NERDTree.InvalidArgumentsError: A TreeDirNode object must be instantiated with a directory Path object."
@@ -394,10 +400,10 @@ function! s:TreeDirNode.New(path, nerdtree)
     return newTreeNode
 endfunction
 
-"FUNCTION: TreeDirNode.open([opts]) {{{1
-"Open the dir in the current tree or in a new tree elsewhere.
+" FUNCTION: TreeDirNode.open([opts]) {{{1
+" Open the dir in the current tree or in a new tree elsewhere.
 "
-"If opening in the current tree, return the number of cached nodes.
+" If opening in the current tree, return the number of cached nodes.
 unlet s:TreeDirNode.open
 function! s:TreeDirNode.open(...)
     let opts = a:0 ? a:1 : {}
@@ -415,10 +421,10 @@ function! s:TreeDirNode.open(...)
     endif
 endfunction
 
-"FUNCTION: TreeDirNode.openAlong([opts]) {{{1
-"recursive open the dir if it has only one directory child.
+" FUNCTION: TreeDirNode.openAlong([opts]) {{{1
+" recursive open the dir if it has only one directory child.
 "
-"return the level of opened directories.
+" return the level of opened directories.
 function! s:TreeDirNode.openAlong(...)
     let opts = a:0 ? a:1 : {}
     let level = 0
@@ -437,42 +443,42 @@ function! s:TreeDirNode.openAlong(...)
 endfunction
 
 " FUNCTION: TreeDirNode.openExplorer() {{{1
-" opens an explorer window for this node in the previous window (could be a
-" nerd tree or a netrw)
+" Open an explorer window for this node in the previous window. The explorer
+" can be a NERDTree window or a netrw window.
 function! s:TreeDirNode.openExplorer()
     call self.open({'where': 'p'})
 endfunction
 
-"FUNCTION: TreeDirNode.openInNewTab(options) {{{1
+" FUNCTION: TreeDirNode.openInNewTab(options) {{{1
 unlet s:TreeDirNode.openInNewTab
 function! s:TreeDirNode.openInNewTab(options)
     call nerdtree#deprecated('TreeDirNode.openInNewTab', 'is deprecated, use open() instead')
     call self.open({'where': 't'})
 endfunction
 
-"FUNCTION: TreeDirNode._openInNewTab() {{{1
+" FUNCTION: TreeDirNode._openInNewTab() {{{1
 function! s:TreeDirNode._openInNewTab()
     tabnew
     call g:NERDTreeCreator.CreateTabTree(self.path.str())
 endfunction
 
-"FUNCTION: TreeDirNode.openRecursively() {{{1
-"Opens this treenode and all of its children whose paths arent 'ignored'
-"because of the file filters.
+" FUNCTION: TreeDirNode.openRecursively() {{{1
+" Opens this treenode and all of its children whose paths arent 'ignored'
+" because of the file filters.
 "
-"This method is actually a wrapper for the OpenRecursively2 method which does
-"the work.
+" This method is actually a wrapper for the OpenRecursively2 method which does
+" the work.
 function! s:TreeDirNode.openRecursively()
     call self._openRecursively2(1)
 endfunction
 
-"FUNCTION: TreeDirNode._openRecursively2() {{{1
-"Opens this all children of this treenode recursively if either:
+" FUNCTION: TreeDirNode._openRecursively2() {{{1
+" Opens this all children of this treenode recursively if either:
 "   *they arent filtered by file filters
 "   *a:forceOpen is 1
 "
-"Args:
-"forceOpen: 1 if this node should be opened regardless of file filters
+" Args:
+" forceOpen: 1 if this node should be opened regardless of file filters
 function! s:TreeDirNode._openRecursively2(forceOpen)
     if self.path.ignore(self.getNerdtree()) ==# 0 || a:forceOpen
         let self.isOpen = 1
@@ -488,7 +494,7 @@ function! s:TreeDirNode._openRecursively2(forceOpen)
     endif
 endfunction
 
-"FUNCTION: TreeDirNode.refresh() {{{1
+" FUNCTION: TreeDirNode.refresh() {{{1
 function! s:TreeDirNode.refresh()
     call self.path.refresh(self.getNerdtree())
 
@@ -527,7 +533,7 @@ function! s:TreeDirNode.refresh()
     endif
 endfunction
 
-"FUNCTION: TreeDirNode.refreshFlags() {{{1
+" FUNCTION: TreeDirNode.refreshFlags() {{{1
 unlet s:TreeDirNode.refreshFlags
 function! s:TreeDirNode.refreshFlags()
     call self.path.refreshFlags(self.getNerdtree())
@@ -536,15 +542,15 @@ function! s:TreeDirNode.refreshFlags()
     endfor
 endfunction
 
-"FUNCTION: TreeDirNode.refreshDirFlags() {{{1
+" FUNCTION: TreeDirNode.refreshDirFlags() {{{1
 function! s:TreeDirNode.refreshDirFlags()
     call self.path.refreshFlags(self.getNerdtree())
 endfunction
 
-"FUNCTION: TreeDirNode.reveal(path) {{{1
-"reveal the given path, i.e. cache and open all treenodes needed to display it
-"in the UI
-"Returns the revealed node
+" FUNCTION: TreeDirNode.reveal(path) {{{1
+" reveal the given path, i.e. cache and open all treenodes needed to display it
+" in the UI
+" Returns the revealed node
 function! s:TreeDirNode.reveal(path, ...)
     let opts = a:0 ? a:1 : {}
 
@@ -571,14 +577,12 @@ function! s:TreeDirNode.reveal(path, ...)
     return n.reveal(a:path, opts)
 endfunction
 
-"FUNCTION: TreeDirNode.removeChild(treenode) {{{1
+" FUNCTION: TreeDirNode.removeChild(treenode) {{{1
+" Remove the given treenode from "self.children".
+" Throws "NERDTree.ChildNotFoundError" if the node is not found.
 "
-"Removes the given treenode from this nodes set of children
-"
-"Args:
-"treenode: the node to remove
-"
-"Throws a NERDTree.ChildNotFoundError if the given treenode is not found
+" Args:
+" treenode: the node object to remove
 function! s:TreeDirNode.removeChild(treenode)
     for i in range(0, self.getChildCount()-1)
         if self.children[i].equals(a:treenode)
@@ -590,18 +594,15 @@ function! s:TreeDirNode.removeChild(treenode)
     throw "NERDTree.ChildNotFoundError: child node was not found"
 endfunction
 
-"FUNCTION: TreeDirNode.sortChildren() {{{1
-"
-"Sorts the children of this node according to alphabetical order and the
-"directory priority.
-"
+" FUNCTION: TreeDirNode.sortChildren() {{{1
+" Sort "self.children" by alphabetical order and directory priority.
 function! s:TreeDirNode.sortChildren()
     let CompareFunc = function("nerdtree#compareNodesBySortKey")
     call sort(self.children, CompareFunc)
 endfunction
 
-"FUNCTION: TreeDirNode.toggleOpen([options]) {{{1
-"Opens this directory if it is closed and vice versa
+" FUNCTION: TreeDirNode.toggleOpen([options]) {{{1
+" Opens this directory if it is closed and vice versa
 function! s:TreeDirNode.toggleOpen(...)
     let opts = a:0 ? a:1 : {}
     if self.isOpen ==# 1
@@ -615,13 +616,13 @@ function! s:TreeDirNode.toggleOpen(...)
     endif
 endfunction
 
-"FUNCTION: TreeDirNode.transplantChild(newNode) {{{1
-"Replaces the child of this with the given node (where the child node's full
-"path matches a:newNode's fullpath). The search for the matching node is
-"non-recursive
+" FUNCTION: TreeDirNode.transplantChild(newNode) {{{1
+" Replaces the child of this with the given node (where the child node's full
+" path matches a:newNode's fullpath). The search for the matching node is
+" non-recursive
 "
-"Arg:
-"newNode: the node to graft into the tree
+" Arg:
+" newNode: the node to graft into the tree
 function! s:TreeDirNode.transplantChild(newNode)
     for i in range(0, self.getChildCount()-1)
         if self.children[i].equals(a:newNode)


### PR DESCRIPTION
This PR involves cleaning up some glaring duplication in the TreeDirNode class. So far, a `_glob()` helper method has been defined and appears to work well.

View the commit messages for the work that has been done so far.

**NOTE:** Need to remember to also close #399 after this pull request gets merged.