### PR TITLE
UPDATE: The `p` mapping now works on cascades.

### DIFF
--- a/autoload/nerdtree/ui_glue.vim
+++ b/autoload/nerdtree/ui_glue.vim
@@ -404,13 +404,27 @@ function! s:jumpToLastChild(node)
 endfunction
 
 " FUNCTION: s:jumpToParent(node) {{{1
-" moves the cursor to the parent of the current node
+" Move the cursor to the parent of the specified node. For a cascade, move to
+" the parent of the cascade's highest node. At the root, do nothing.
 function! s:jumpToParent(node)
-    if !empty(a:node.parent)
-        call a:node.parent.putCursorHere(1, 0)
+    let l:parent = a:node.parent
+
+    " If "a:node" represents a directory, back out of its cascade.
+    if a:node.path.isDirectory
+        while !empty(l:parent) && !l:parent.isRoot()
+            if index(l:parent.getCascade(), a:node) >= 0
+                let l:parent = l:parent.parent
+            else
+                break
+            endif
+        endwhile
+    endif
+
+    if !empty(l:parent)
+        call l:parent.putCursorHere(1, 0)
         call b:NERDTree.ui.centerView()
     else
-        call nerdtree#echo("cannot jump to parent")
+        call nerdtree#echo('could not jump to parent node')
     endif
 endfunction
 


### PR DESCRIPTION
This pull request fixes issue #67.