### PR TITLE
Open Bookmarks with Closed Children

### DIFF
--- a/lib/nerdtree/bookmark.vim
+++ b/lib/nerdtree/bookmark.vim
@@ -308,10 +308,11 @@ function! s:Bookmark.toRoot(nerdtree)
 endfunction
 
 " FUNCTION: Bookmark.ToRoot(name, nerdtree) {{{1
-" Make the node for this bookmark the new tree root
+" Class method that makes the Bookmark with the given name the root of
+" specified NERDTree.
 function! s:Bookmark.ToRoot(name, nerdtree)
-    let bookmark = s:Bookmark.BookmarkFor(a:name)
-    call bookmark.toRoot(a:nerdtree)
+    let l:bookmark = s:Bookmark.BookmarkFor(a:name)
+    call l:bookmark.toRoot(a:nerdtree)
 endfunction
 
 " FUNCTION: Bookmark.validate() {{{1

--- a/lib/nerdtree/bookmark.vim
+++ b/lib/nerdtree/bookmark.vim
@@ -293,15 +293,17 @@ function! s:Bookmark.str()
 endfunction
 
 " FUNCTION: Bookmark.toRoot(nerdtree) {{{1
-" Make the node for this bookmark the new tree root
+" Set the root of the given NERDTree to the node for this Bookmark. If a node
+" for this Bookmark does not exist, a new one is initialized.
 function! s:Bookmark.toRoot(nerdtree)
     if self.validate()
         try
-            let targetNode = self.getNode(a:nerdtree, 1)
+            let l:targetNode = self.getNode(a:nerdtree, 1)
+            call l:targetNode.closeChildren()
         catch /^NERDTree.BookmarkedNodeNotFoundError/
-            let targetNode = g:NERDTreeFileNode.New(s:Bookmark.BookmarkFor(self.name).path, a:nerdtree)
+            let l:targetNode = g:NERDTreeFileNode.New(s:Bookmark.BookmarkFor(self.name).path, a:nerdtree)
         endtry
-        call a:nerdtree.changeRoot(targetNode)
+        call a:nerdtree.changeRoot(l:targetNode)
     endif
 endfunction
 

--- a/lib/nerdtree/tree_dir_node.vim
+++ b/lib/nerdtree/tree_dir_node.vim
@@ -220,13 +220,6 @@ function! s:TreeDirNode.getChildIndex(path)
     return -1
 endfunction
 
-" FUNCTION: TreeDirNode.getDirChildren() {{{1
-" Return a list of all child nodes from "self.children" that are of type
-" TreeDirNode.
-function! s:TreeDirNode.getDirChildren()
-    return filter(self.children, 'v:val.path.isDirectory == 1')
-endfunction
-
 " FUNCTION: TreeDirNode._glob(pattern, all) {{{1
 " Return a list of strings naming the descendants of the directory in this
 " TreeDirNode object that match the specified glob pattern.

--- a/lib/nerdtree/tree_dir_node.vim
+++ b/lib/nerdtree/tree_dir_node.vim
@@ -56,12 +56,12 @@ function! s:TreeDirNode.close()
 endfunction
 
 " FUNCTION: TreeDirNode.closeChildren() {{{1
-" Closes all the child dir nodes of this node
+" Recursively close any directory nodes that are descendants of this node.
 function! s:TreeDirNode.closeChildren()
-    for i in self.children
-        if i.path.isDirectory
-            call i.close()
-            call i.closeChildren()
+    for l:child in self.children
+        if l:child.path.isDirectory
+            call l:child.close()
+            call l:child.closeChildren()
         endif
     endfor
 endfunction


### PR DESCRIPTION
This little enhancement causes bookmarks to be opened (i.e., made the NERDTree root) with their children closed. This gives an immediate "fresh" appearance to the directory which is less noisy.

The alternative is to have open children retained as open. This is not desirable in large projects with complex (and often messy) hierarchies.