### PR TITLE
Update README.markdown to fix script error E580

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -96,7 +96,7 @@ Stick this in your vimrc: `autocmd vimenter * NERDTree`
 Stick this in your vimrc:
 
     autocmd StdinReadPre * let s:std_in=1
-    autocmd VimEnter * if argc() == 0 && !exists("s:std_in") | NERDTree | endif
+    autocmd VimEnter * if argc() == 0 && !exists("s:std_in") | exe 'NERDTree' | endif
 
 Note: Now start vim with plain `vim`, not `vim .`
 


### PR DESCRIPTION
`autocmd VimEnter * if argc() == 0 && !exists("s:std_in") | NERDTree | endif`   
would report error  
`E580: :endif without :if: endif`  
change to  
`autocmd VimEnter * if argc() == 0 && !exists("s:std_in") | exe 'NERDTree' | endif`
fixit