### PR TITLE
mirror a tree witch tab already closed

### DIFF
--- a/lib/nerdtree/creator.vim
+++ b/lib/nerdtree/creator.vim
@@ -134,6 +134,13 @@ function! s:Creator.createMirror()
             call add(treeBufNames, nextName)
         endif
     endfor
+
+    for i in range(1, bufnr('$'))
+        let nextName = bufname(i)
+        if bufexists(i) && getbufvar(i, '&filetype') == 'nerdtree' && (!exists("t:NERDTreeBufName") || nextName != t:NERDTreeBufName)
+            call add(treeBufNames, nextName)
+        endif
+    endfor
     let treeBufNames = self._uniq(treeBufNames)
 
     "map the option names (that the user will be prompted with) to the nerd


### PR DESCRIPTION
I using tabs for multi-file editing instead of using buffers, And nerdtree monitor is quite useful for speed up file browses in a large project. but it nerdtree monitor can not wrok when tab closed, so ...