### PR TITLE
fixed: directory navigation does not work on Cygwin

### DIFF
--- a/autoload/nerdtree.vim
+++ b/autoload/nerdtree.vim
@@ -155,6 +155,11 @@ function! nerdtree#runningWindows()
     return has("win16") || has("win32") || has("win64")
 endfunction
 
+"FUNCTION: nerdtree#runningCygwin(dir) {{{2
+function! nerdtree#runningCygwin()
+    return has("win32unix")
+endfunction
+
 " SECTION: View Functions {{{1
 "============================================================
 

--- a/plugin/NERD_tree.vim
+++ b/plugin/NERD_tree.vim
@@ -69,7 +69,7 @@ call s:initVariable("g:NERDTreeShowHidden", 0)
 call s:initVariable("g:NERDTreeShowLineNumbers", 0)
 call s:initVariable("g:NERDTreeSortDirs", 1)
 
-if !nerdtree#runningWindows()
+if !nerdtree#runningWindows() && !nerdtree#runningCygwin()
     call s:initVariable("g:NERDTreeDirArrowExpandable", "▸")
     call s:initVariable("g:NERDTreeDirArrowCollapsible", "▾")
 else


### PR DESCRIPTION
Directory tree navigation is broken because of directory signs which is
shown in UTF-8.

Cygwin is a Windows application, so it uses ASCII codepages and so
directory signs must be in ASCII, but if to modify
"nerdtree#runningWindows" function there are many other functions break
that convert paths, e.g.

So, the quick and reliable solution is to add a
separate function "nerdtree#runningCygwin" and use it in a specific
place.