### PR TITLE
Display file size with commas as thousands separators.

### DIFF
--- a/nerdtree_plugin/fs_menu.vim
+++ b/nerdtree_plugin/fs_menu.vim
@@ -213,7 +213,7 @@ function! NERDTreeListNode()
         \         'size_with_commas=$(echo $size | sed -e :a -e "s/\(.*[0-9]\)\([0-9]\{3\}\)/\1,\2/;ta") && ' .
         \         'ls -ld ' . shellescape(treenode.path.str()) . ' | sed -e "s/ $size / $size_with_commas /"'
 
-        let metadata = systemlist(cmd)
+        let metadata = split(system(cmd),'\n')
         call nerdtree#echo(metadata[0])
     else
         call nerdtree#echo("No information available")

--- a/nerdtree_plugin/fs_menu.vim
+++ b/nerdtree_plugin/fs_menu.vim
@@ -211,9 +211,7 @@ function! NERDTreeListNode()
 
         let cmd = 'size=$(' . stat_cmd . shellescape(treenode.path.str()) . ') && ' .
         \         'size_with_commas=$(echo $size | sed -e :a -e "s/\(.*[0-9]\)\([0-9]\{3\}\)/\1,\2/;ta") && ' .
-        \         'ls -ld ' . shellescape(treenode.path.str()) . ' | sed -e "s/ $size / $size_with_commas /" && ' .
-        \         'unset size && ' .
-        \         'unset size_with_commas'
+        \         'ls -ld ' . shellescape(treenode.path.str()) . ' | sed -e "s/ $size / $size_with_commas /"'
 
         let metadata = systemlist(cmd)
         call nerdtree#echo(metadata[0])

--- a/nerdtree_plugin/fs_menu.vim
+++ b/nerdtree_plugin/fs_menu.vim
@@ -202,7 +202,7 @@ endfunction
 " FUNCTION: NERDTreeListNode() {{{1
 function! NERDTreeListNode()
     let treenode = g:NERDTreeFileNode.GetSelected()
-    if treenode != {}
+    if !empty(treenode)
         if has("osx")
             let stat_cmd = 'stat -f "%z" '
         else
@@ -215,7 +215,7 @@ function! NERDTreeListNode()
         \         'unset size && ' .
         \         'unset size_with_commas'
 
-        let metadata = split(system(cmd),'\n')
+        let metadata = systemlist(cmd)
         call nerdtree#echo(metadata[0])
     else
         call nerdtree#echo("No information available")

--- a/nerdtree_plugin/fs_menu.vim
+++ b/nerdtree_plugin/fs_menu.vim
@@ -203,10 +203,22 @@ endfunction
 function! NERDTreeListNode()
     let treenode = g:NERDTreeFileNode.GetSelected()
     if treenode != {}
-        let metadata = split(system('ls -ld ' . shellescape(treenode.path.str())), '\n')
+        if has("osx")
+            let stat_cmd = 'stat -f "%z" '
+        else
+            let stat_cmd = 'stat -c "%s" '
+        endif
+
+        let cmd = 'size=$(' . stat_cmd . shellescape(treenode.path.str()) . ') && ' .
+        \         'size_with_commas=$(echo $size | sed -e :a -e "s/\(.*[0-9]\)\([0-9]\{3\}\)/\1,\2/;ta") && ' .
+        \         'ls -ld ' . shellescape(treenode.path.str()) . ' | sed -e "s/ $size / $size_with_commas /" && ' .
+        \         'unset size && ' .
+        \         'unset size_with_commas'
+
+        let metadata = split(system(cmd),'\n')
         call nerdtree#echo(metadata[0])
     else
-        call nerdtree#echo("No information avaialable")
+        call nerdtree#echo("No information available")
     endif
 endfunction
 


### PR DESCRIPTION
This change will display the file size in an easier to read format, and
still display its exact value. It uses the stat command (with different
switches and formats between Unix and OSX) to get the file size, sed to
add the commas to it, and sed again to replace the original size with
the modified number.