### PR TITLE
NERDTree keeps 'No Name' buffer after deleting current node 'md' #755 (closes #755)

### DIFF
--- a/nerdtree_plugin/fs_menu.vim
+++ b/nerdtree_plugin/fs_menu.vim
@@ -55,7 +55,14 @@ function! s:promptToDelBuffer(bufnum, msg)
         " Is not it better to close single tabs with this file only ?
         let s:originalTabNumber = tabpagenr()
         let s:originalWindowNumber = winnr()
-        exec "tabdo windo if winbufnr(0) == " . a:bufnum . " | exec ':bnext! ' | endif"
+        let s:listedBufferCount = len(getbufinfo({'buflisted':1}))
+        " Go to the next buffer in buffer list if at least one extra buffer is listed
+        " Otherwise open a new empty buffer
+        if s:listedBufferCount > 1
+            exec "tabdo windo if winbufnr(0) == " . a:bufnum . " | exec ':bnext! ' | endif"
+        else
+            exec "tabdo windo if winbufnr(0) == " . a:bufnum . " | exec ':enew! ' | endif"
+        endif
         exec "tabnext " . s:originalTabNumber
         exec s:originalWindowNumber . "wincmd w"
         " 3. We don't need a previous buffer anymore

--- a/nerdtree_plugin/fs_menu.vim
+++ b/nerdtree_plugin/fs_menu.vim
@@ -55,9 +55,17 @@ function! s:promptToDelBuffer(bufnum, msg)
         " Is not it better to close single tabs with this file only ?
         let s:originalTabNumber = tabpagenr()
         let s:originalWindowNumber = winnr()
-        let s:listedBufferCount = len(getbufinfo({'buflisted':1}))
         " Go to the next buffer in buffer list if at least one extra buffer is listed
         " Otherwise open a new empty buffer
+        if v:version >= 800
+            let s:listedBufferCount = len(getbufinfo({'buflisted':1}))
+        elseif v:version >= 702
+            let s:listedBufferCount = len(filter(range(1, bufnr('$')), 'buflisted(v:val)'))
+        else
+            " Ignore buffer count in this case to make sure we keep the old
+            " behavior
+            let s:listedBufferCount = 0
+        endif
         if s:listedBufferCount > 1
             exec "tabdo windo if winbufnr(0) == " . a:bufnum . " | exec ':bnext! ' | endif"
         else

--- a/nerdtree_plugin/fs_menu.vim
+++ b/nerdtree_plugin/fs_menu.vim
@@ -55,7 +55,7 @@ function! s:promptToDelBuffer(bufnum, msg)
         " Is not it better to close single tabs with this file only ?
         let s:originalTabNumber = tabpagenr()
         let s:originalWindowNumber = winnr()
-        exec "tabdo windo if winbufnr(0) == " . a:bufnum . " | exec ':enew! ' | endif"
+        exec "tabdo windo if winbufnr(0) == " . a:bufnum . " | exec ':bnext! ' | endif"
         exec "tabnext " . s:originalTabNumber
         exec s:originalWindowNumber . "wincmd w"
         " 3. We don't need a previous buffer anymore

--- a/nerdtree_plugin/fs_menu.vim
+++ b/nerdtree_plugin/fs_menu.vim
@@ -58,15 +58,15 @@ function! s:promptToDelBuffer(bufnum, msg)
         " Go to the next buffer in buffer list if at least one extra buffer is listed
         " Otherwise open a new empty buffer
         if v:version >= 800
-            let s:listedBufferCount = len(getbufinfo({'buflisted':1}))
+            let l:listedBufferCount = len(getbufinfo({'buflisted':1}))
         elseif v:version >= 702
-            let s:listedBufferCount = len(filter(range(1, bufnr('$')), 'buflisted(v:val)'))
+            let l:listedBufferCount = len(filter(range(1, bufnr('$')), 'buflisted(v:val)'))
         else
             " Ignore buffer count in this case to make sure we keep the old
             " behavior
-            let s:listedBufferCount = 0
+            let l:listedBufferCount = 0
         endif
-        if s:listedBufferCount > 1
+        if l:listedBufferCount > 1
             exec "tabdo windo if winbufnr(0) == " . a:bufnum . " | exec ':bnext! ' | endif"
         else
             exec "tabdo windo if winbufnr(0) == " . a:bufnum . " | exec ':enew! ' | endif"


### PR DESCRIPTION
Go to the new buffer in buffer list instead of creating a new buffer.
If only one buffer is open, now we go back to nerdtree buffer.