### PR TITLE
Fix a problem with the "x" handler

### DIFF
--- a/autoload/nerdtree/ui_glue.vim
+++ b/autoload/nerdtree/ui_glue.vim
@@ -194,14 +194,14 @@ function! s:closeCurrentDir(node)
 
     let l:parent = a:node.parent
 
-    if empty(l:parent) || l:parent.isRoot()
-        call nerdtree#echo('cannot close tree root')
-        return
-    endif
-
     while l:parent.isCascadable()
         let l:parent = l:parent.parent
     endwhile
+
+    if l:parent.isRoot()
+        call nerdtree#echo('cannot close tree root')
+        return
+    endif
 
     call l:parent.close()
     call b:NERDTree.render()


### PR DESCRIPTION
Pressing "x" on a cascade could close the root of the tree.  This
commit prevents that from happening.