### PR TITLE
Make the "o" mapping consistent with "x"

### DIFF
--- a/autoload/nerdtree/ui_glue.vim
+++ b/autoload/nerdtree/ui_glue.vim
@@ -90,10 +90,15 @@ function! s:activateAll()
     endif
 endfunction
 
-"FUNCTION: s:activateDirNode() {{{1
-"handle the user activating a tree node
-function! s:activateDirNode(node)
-    call a:node.activate()
+" FUNCTION: s:activateDirNode(directoryNode) {{{1
+function! s:activateDirNode(directoryNode)
+
+    if a:directoryNode.isRoot() && a:directoryNode.isOpen
+        call nerdtree#echo('cannot close tree root')
+        return
+    endif
+
+    call a:directoryNode.activate()
 endfunction
 
 "FUNCTION: s:activateFileNode() {{{1


### PR DESCRIPTION
The "o" mapping, which toggles directory nodes open/closed, allowed
the user to close the tree root.  This was not consistent with the
"x" mapping which stops the user from doing this.  This applies to
a double-click on the root node as well.

It should be noted that, if the root node is somehow closed, "o" and
double click can still re-open the tree, even with this change.  In
other words, I was careful.