### PR TITLE
BUGFIX:  Allow ":NERDTreeFind" to reveal new files

### DIFF
--- a/autoload/nerdtree/ui_glue.vim
+++ b/autoload/nerdtree/ui_glue.vim
@@ -270,13 +270,13 @@ function! s:findAndRevealPath(path)
     endif
     
     try
-        let p = g:NERDTreePath.New(l:path)
+        let l:p = g:NERDTreePath.New(l:path)
     catch /^NERDTree.InvalidArgumentsError/
-        call nerdtree#echo("no file for the current buffer")
+        call nerdtree#echo('no file for the current buffer')
         return
     endtry
 
-    if p.isUnixHiddenPath()
+    if l:p.isUnixHiddenPath()
         let showhidden=g:NERDTreeShowHidden
         let g:NERDTreeShowHidden = 1
     endif
@@ -285,36 +285,29 @@ function! s:findAndRevealPath(path)
         try
             let cwd = g:NERDTreePath.New(getcwd())
         catch /^NERDTree.InvalidArgumentsError/
-            call nerdtree#echo("current directory does not exist.")
-            let cwd = p.getParent()
+            call nerdtree#echo('current directory does not exist.')
+            let cwd = l:p.getParent()
         endtry
 
-        if p.isUnder(cwd)
+        if l:p.isUnder(cwd)
             call g:NERDTreeCreator.CreateTabTree(cwd.str())
         else
-            call g:NERDTreeCreator.CreateTabTree(p.getParent().str())
+            call g:NERDTreeCreator.CreateTabTree(l:p.getParent().str())
         endif
     else
-        if !p.isUnder(g:NERDTreeFileNode.GetRootForTab().path)
-            if !g:NERDTree.IsOpen()
-                call g:NERDTreeCreator.ToggleTabTree('')
-            else
-                call g:NERDTree.CursorToTreeWin()
-            endif
+        NERDTreeFocus
+
+        if !l:p.isUnder(g:NERDTreeFileNode.GetRootForTab().path)
             call b:NERDTree.ui.setShowHidden(g:NERDTreeShowHidden)
-            call s:chRoot(g:NERDTreeDirNode.New(p.getParent(), b:NERDTree))
-        else
-            if !g:NERDTree.IsOpen()
-                call g:NERDTreeCreator.ToggleTabTree("")
-            endif
+            call s:chRoot(g:NERDTreeDirNode.New(l:p.getParent(), b:NERDTree))
         endif
     endif
-    call g:NERDTree.CursorToTreeWin()
-    let node = b:NERDTree.root.reveal(p)
+
+    let node = b:NERDTree.root.reveal(l:p)
     call b:NERDTree.render()
     call node.putCursorHere(1,0)
 
-    if p.isUnixHiddenFile()
+    if l:p.isUnixHiddenFile()
         let g:NERDTreeShowHidden = showhidden
     endif
 endfunction

--- a/autoload/nerdtree/ui_glue.vim
+++ b/autoload/nerdtree/ui_glue.vim
@@ -270,45 +270,45 @@ function! s:findAndRevealPath(path)
     endif
     
     try
-        let l:p = g:NERDTreePath.New(l:path)
+        let l:pathObj = g:NERDTreePath.New(l:path)
     catch /^NERDTree.InvalidArgumentsError/
         call nerdtree#echo('no file for the current buffer')
         return
     endtry
 
-    if l:p.isUnixHiddenPath()
-        let showhidden=g:NERDTreeShowHidden
+    if l:pathObj.isUnixHiddenPath()
+        let l:showHidden = g:NERDTreeShowHidden
         let g:NERDTreeShowHidden = 1
     endif
 
     if !g:NERDTree.ExistsForTab()
         try
-            let cwd = g:NERDTreePath.New(getcwd())
+            let l:cwd = g:NERDTreePath.New(getcwd())
         catch /^NERDTree.InvalidArgumentsError/
             call nerdtree#echo('current directory does not exist.')
-            let cwd = l:p.getParent()
+            let l:cwd = l:pathObj.getParent()
         endtry
 
-        if l:p.isUnder(cwd)
-            call g:NERDTreeCreator.CreateTabTree(cwd.str())
+        if l:pathObj.isUnder(l:cwd)
+            call g:NERDTreeCreator.CreateTabTree(l:cwd.str())
         else
-            call g:NERDTreeCreator.CreateTabTree(l:p.getParent().str())
+            call g:NERDTreeCreator.CreateTabTree(l:pathObj.getParent().str())
         endif
     else
         NERDTreeFocus
 
-        if !l:p.isUnder(g:NERDTreeFileNode.GetRootForTab().path)
+        if !l:pathObj.isUnder(g:NERDTreeFileNode.GetRootForTab().path)
             call b:NERDTree.ui.setShowHidden(g:NERDTreeShowHidden)
-            call s:chRoot(g:NERDTreeDirNode.New(l:p.getParent(), b:NERDTree))
+            call s:chRoot(g:NERDTreeDirNode.New(l:pathObj.getParent(), b:NERDTree))
         endif
     endif
 
-    let node = b:NERDTree.root.reveal(l:p)
+    let l:node = b:NERDTree.root.reveal(l:pathObj)
     call b:NERDTree.render()
-    call node.putCursorHere(1,0)
+    call l:node.putCursorHere(1, 0)
 
-    if l:p.isUnixHiddenFile()
-        let g:NERDTreeShowHidden = showhidden
+    if l:pathObj.isUnixHiddenFile()
+        let g:NERDTreeShowHidden = l:showHidden
     endif
 endfunction
 

--- a/autoload/nerdtree/ui_glue.vim
+++ b/autoload/nerdtree/ui_glue.vim
@@ -261,18 +261,19 @@ function! s:displayHelp()
     call b:NERDTree.ui.centerView()
 endfunction
 
-" FUNCTION: s:findAndRevealPath(path) {{{1
-function! s:findAndRevealPath(path)
-    let l:path = a:path
+" FUNCTION: s:findAndRevealPath(pathStr) {{{1
+function! s:findAndRevealPath(pathStr)
+    let l:pathStr = !empty(a:pathStr) ? a:pathStr : expand('%:p')
 
-    if empty(l:path)
-        let l:path = expand('%:p')
+    if empty(l:pathStr)
+        call nerdtree#echoWarning('no file for the current buffer')
+        return
     endif
-    
+
     try
-        let l:pathObj = g:NERDTreePath.New(l:path)
+        let l:pathObj = g:NERDTreePath.New(l:pathStr)
     catch /^NERDTree.InvalidArgumentsError/
-        call nerdtree#echo('no file for the current buffer')
+        call nerdtree#echoWarning('invalid path')
         return
     endtry
 

--- a/autoload/nerdtree/ui_glue.vim
+++ b/autoload/nerdtree/ui_glue.vim
@@ -304,11 +304,6 @@ function! s:findAndRevealPath(path)
     endif
 
     let l:node = b:NERDTree.root.reveal(l:pathObj)
-
-    if empty(l:node)
-        echomsg 'l:node is totally empty...'
-    endif
-
     call b:NERDTree.render()
     call l:node.putCursorHere(1, 0)
 

--- a/autoload/nerdtree/ui_glue.vim
+++ b/autoload/nerdtree/ui_glue.vim
@@ -304,6 +304,11 @@ function! s:findAndRevealPath(path)
     endif
 
     let l:node = b:NERDTree.root.reveal(l:pathObj)
+
+    if empty(l:node)
+        echomsg 'l:node is totally empty...'
+    endif
+
     call b:NERDTree.render()
     call l:node.putCursorHere(1, 0)
 

--- a/doc/NERDTree.txt
+++ b/doc/NERDTree.txt
@@ -126,20 +126,20 @@ The following features and functionality are provided by the NERD tree:
     Changes made to one tree are reflected in both as they are actually the
     same buffer.
 
-    If only one other NERD tree exists, that tree is automatically mirrored. If
-    more than one exists, the script will ask which tree to mirror.
+    If only one other NERD tree exists, that tree is automatically mirrored.
+    If more than one exists, the script will ask which tree to mirror.
 
 :NERDTreeClose                                                *:NERDTreeClose*
     Close the NERD tree in this tab.
 
-:NERDTreeFind                                                  *:NERDTreeFind*
-    Find the current file in the tree.
+:NERDTreeFind [<path>]                                         *:NERDTreeFind*
+    Without the optional argument, find and reveal the file for the active
+    buffer in the NERDTree window.  With the <path> argument, find and
+    reveal the specified path.
 
-    If no tree exists and the current file is under vim's CWD, then init a
-    tree at the CWD and reveal the file. Otherwise init a tree in the current
-    file's directory.
-
-    In any case, the current file is revealed and the cursor is placed on it.
+    Focus will be shifted to the NERDTree window, and the cursor will be
+    placed on the tree node for the determined path.  If a NERDTree for the
+    current tab does not exist, a new one will be initialized.
 
 :NERDTreeCWD                                                    *:NERDTreeCWD*
     Change tree root to current directory. If no NERD tree exists for this
@@ -1128,13 +1128,12 @@ NERDTreeAddKeyMap({options})                             *NERDTreeAddKeyMap()*
     Additionally, a "scope" argument may be supplied. This constrains the
     mapping so that it is only activated if the cursor is on a certain object.
     That object is then passed into the handling method. Possible values are:
-        "FileNode" - a file node
-        "DirNode" - a directory node
-        "Node" - a file or directory node
-        "Bookmark" - A bookmark
-        "all" - the keymap is not constrained to any scope (default). When
-        thei is used, the handling function is not passed any arguments.
 
+      "FileNode" .... a file node
+      "DirNode" ..... a directory node
+      "Node" ........ a file node OR a directory node
+      "Bookmark" .... a bookmark
+      "all" ......... global scope; handler receives no arguments (default)
 
     Example: >
         call NERDTreeAddKeyMap({

--- a/lib/nerdtree/tree_dir_node.vim
+++ b/lib/nerdtree/tree_dir_node.vim
@@ -568,6 +568,13 @@ function! s:TreeDirNode.reveal(path, ...)
         throw "NERDTree.InvalidArgumentsError: " . a:path.str() . " should be under " . self.path.str()
     endif
 
+    " Refresh "self.children" to avoid missing paths created after this node
+    " was last opened.  If "self.children" is empty, the call to "open()" will
+    " initialize the children.
+    if !empty(self.children)
+        " Silence messages/errors. They were seen on the first open.
+        silent! call self._initChildren(1)
+    endif
     call self.open()
 
     if self.path.equals(a:path.getParent())


### PR DESCRIPTION
Here, I'm addressing issue #779.

When a new file is written *after* the NERDTree for the current tab has been initialized, attempting to use `:NERDTreeFind` on that new file will fail with an error message. The reason for this is subtle, but it has to do with the following functions:

1. `NEDRTreeDirNode.reveal()`  (this is what really drives the `:NERDTreeFind` command)
2. `NERDTreeDirNode.open()`
3. `NERDTreeDirNode._initChildren()`

First, note that `reveal()` must `open()` all nodes along the path, starting with root, to "get to" the desired node.  Also note: `open()` calls `_initChildren()` **only if** the node's children *have not yet been initialized*.  This is for efficiency... but doesn't help much here because nodes will likely need to be opened anyway.  It only helps if one of the dirs along the path has *already* been opened and has, say 200+ children.

That last point is the key.  When the root is `open()`ed, it's children are *not* checked again.  However, if we create a new file several dirs deep (dirs that have not yet been opened), the `:NERDTreeFind` call will succeed because the dirs along the path are opened *after* the path was created.

In effect, the find command is searching the tree, not the file system... so some mechanism is needed to "freshly open" the nodes along the search path as we go.  We can be sure the path exists, we just need to make sure it's guaranteed to be in the tree when we get there!

The last commit on this branch fixes the issue in the most efficient way possible... but some may still find it undesirable... Read the comment in that commit when it shows up to see why it's most efficient... 

Oh, and feed back will be appreciated!





