### PR TITLE
BUGFIX:  Allow ":NERDTreeFind" to discover hidden files

### DIFF
--- a/autoload/nerdtree/ui_glue.vim
+++ b/autoload/nerdtree/ui_glue.vim
@@ -277,11 +277,6 @@ function! s:findAndRevealPath(pathStr)
         return
     endtry
 
-    if l:pathObj.isUnixHiddenPath()
-        let l:showHidden = g:NERDTreeShowHidden
-        let g:NERDTreeShowHidden = 1
-    endif
-
     if !g:NERDTree.ExistsForTab()
         try
             let l:cwd = g:NERDTreePath.New(getcwd())
@@ -298,19 +293,18 @@ function! s:findAndRevealPath(pathStr)
     else
         NERDTreeFocus
 
-        if !l:pathObj.isUnder(g:NERDTreeFileNode.GetRootForTab().path)
-            call b:NERDTree.ui.setShowHidden(g:NERDTreeShowHidden)
+        if !l:pathObj.isUnder(b:NERDTree.root.path)
             call s:chRoot(g:NERDTreeDirNode.New(l:pathObj.getParent(), b:NERDTree))
         endif
+    endif
+
+    if l:pathObj.isHiddenUnder(b:NERDTree.root.path)
+        call b:NERDTree.ui.setShowHidden(1)
     endif
 
     let l:node = b:NERDTree.root.reveal(l:pathObj)
     call b:NERDTree.render()
     call l:node.putCursorHere(1, 0)
-
-    if l:pathObj.isUnixHiddenFile()
-        let g:NERDTreeShowHidden = l:showHidden
-    endif
 endfunction
 
 "FUNCTION: s:handleLeftClick() {{{1

--- a/lib/nerdtree/path.vim
+++ b/lib/nerdtree/path.vim
@@ -405,6 +405,25 @@ function! s:Path.getSortKey()
     return self._sortKey
 endfunction
 
+" FUNCTION: Path.isHiddenUnder(path) {{{1
+function! s:Path.isHiddenUnder(path)
+    
+    if !self.isUnder(a:path)
+        return 0
+    endif
+
+    let l:startIndex = len(a:path.pathSegments)
+    let l:segments = self.pathSegments[l:startIndex:]
+
+    for l:segment in l:segments
+        
+        if l:segment =~# '^\.'
+            return 1
+        endif
+    endfor
+
+    return 0
+endfunction
 
 " FUNCTION: Path.isUnixHiddenFile() {{{1
 " check for unix hidden files

--- a/lib/nerdtree/path.vim
+++ b/lib/nerdtree/path.vim
@@ -413,7 +413,7 @@ function! s:Path.isHiddenUnder(path)
     endif
 
     let l:startIndex = len(a:path.pathSegments)
-    let l:segments = self.pathSegments[l:startIndex:]
+    let l:segments = self.pathSegments[l:startIndex : ]
 
     for l:segment in l:segments
         


### PR DESCRIPTION
Issue #189 originally pointed out a bug in which `:NERDTreeFind` could not always properly reveal a hidden file.  This PR adds a function that makes the behavior of `findAndRevealPath()` consistent in this respect.
