### PR TITLE
Revert the bugfix from pull request #785

### DIFF
--- a/lib/nerdtree/tree_dir_node.vim
+++ b/lib/nerdtree/tree_dir_node.vim
@@ -568,13 +568,6 @@ function! s:TreeDirNode.reveal(path, ...)
         throw "NERDTree.InvalidArgumentsError: " . a:path.str() . " should be under " . self.path.str()
     endif
 
-    " Refresh "self.children" to avoid missing paths created after this node
-    " was last opened.  If "self.children" is empty, the call to "open()" will
-    " initialize the children.
-    if !empty(self.children)
-        " Silence messages/errors. They were seen on the first open.
-        silent! call self._initChildren(1)
-    endif
     call self.open()
 
     if self.path.equals(a:path.getParent())


### PR DESCRIPTION
The small change here reverts an attempted bugfix from pull request
children of the root whenever ":NERDTreeFind" was invoked.  This was
disruptive (as reported in #793), so a new method must be found to
solve the problem of ":NERDTreeFind" not opening newly created
files.

Fixes #793.