### PR TITLE
BUGFIX: Unstable behavior in the "getPath()" method

### DIFF
--- a/lib/nerdtree/path.vim
+++ b/lib/nerdtree/path.vim
@@ -541,17 +541,16 @@ function! s:Path.equals(path)
     return self.str() ==# a:path.str()
 endfunction
 
-" FUNCTION: Path.New() {{{1
-" The Constructor for the Path object
-function! s:Path.New(path)
-    let newPath = copy(self)
+" FUNCTION: Path.New(pathStr) {{{1
+function! s:Path.New(pathStr)
+    let l:newPath = copy(self)
 
-    call newPath.readInfoFromDisk(s:Path.AbsolutePathFor(a:path))
+    call l:newPath.readInfoFromDisk(s:Path.AbsolutePathFor(a:pathStr))
 
-    let newPath.cachedDisplayString = ""
-    let newPath.flagSet = g:NERDTreeFlagSet.New()
+    let l:newPath.cachedDisplayString = ''
+    let l:newPath.flagSet = g:NERDTreeFlagSet.New()
 
-    return newPath
+    return l:newPath
 endfunction
 
 " FUNCTION: Path.Slash() {{{1

--- a/lib/nerdtree/path.vim
+++ b/lib/nerdtree/path.vim
@@ -14,21 +14,23 @@ lockvar s:NERDTreeSortStarIndex
 let s:Path = {}
 let g:NERDTreePath = s:Path
 
-" FUNCTION: Path.AbsolutePathFor(str) {{{1
-function! s:Path.AbsolutePathFor(str)
-    let prependCWD = 0
+" FUNCTION: Path.AbsolutePathFor(pathStr) {{{1
+function! s:Path.AbsolutePathFor(pathStr)
+    let l:prependWorkingDir = 0
+
     if nerdtree#runningWindows()
-        let prependCWD = a:str !~# '^.:\(\\\|\/\)' && a:str !~# '^\(\\\\\|\/\/\)'
+        let l:prependWorkingDir = a:pathStr !~# '^.:\(\\\|\/\)' && a:pathStr !~# '^\(\\\\\|\/\/\)'
     else
-        let prependCWD = a:str !~# '^/'
+        let l:prependWorkingDir = a:pathStr !~# '^/'
     endif
 
-    let toReturn = a:str
-    if prependCWD
-        let toReturn = getcwd() . s:Path.Slash() . a:str
+    let l:result = a:pathStr
+
+    if l:prependWorkingDir
+        let l:result = getcwd() . s:Path.Slash() . a:pathStr
     endif
 
-    return toReturn
+    return l:result
 endfunction
 
 " FUNCTION: Path.bookmarkNames() {{{1

--- a/lib/nerdtree/tree_file_node.vim
+++ b/lib/nerdtree/tree_file_node.vim
@@ -196,14 +196,18 @@ function! s:TreeFileNode.GetRootForTab()
 endfunction
 
 " FUNCTION: TreeFileNode.GetSelected() {{{1
-" gets the treenode that the cursor is currently over
+" If the cursor is currently positioned on a tree node, return the node.
+" Otherwise, return the empty dictionary.
 function! s:TreeFileNode.GetSelected()
+
     try
-        let path = b:NERDTree.ui.getPath(line("."))
-        if path ==# {}
+        let l:path = b:NERDTree.ui.getPath(line('.'))
+
+        if empty(l:path)
             return {}
         endif
-        return b:NERDTree.root.findNode(path)
+
+        return b:NERDTree.root.findNode(l:path)
     catch /^NERDTree/
         return {}
     endtry

--- a/lib/nerdtree/tree_file_node.vim
+++ b/lib/nerdtree/tree_file_node.vim
@@ -1,22 +1,25 @@
-"CLASS: TreeFileNode
-"This class is the parent of the TreeDirNode class and is the
-"'Component' part of the composite design pattern between the treenode
-"classes.
-"============================================================
+" ============================================================================
+" CLASS: TreeFileNode
+"
+" This class is the parent of the "TreeDirNode" class and is the "Component"
+" part of the composite design pattern between the NERDTree node classes.
+" ============================================================================
+
+
 let s:TreeFileNode = {}
 let g:NERDTreeFileNode = s:TreeFileNode
 
-"FUNCTION: TreeFileNode.activate(...) {{{1
+" FUNCTION: TreeFileNode.activate(...) {{{1
 function! s:TreeFileNode.activate(...)
     call self.open(a:0 ? a:1 : {})
 endfunction
 
-"FUNCTION: TreeFileNode.bookmark(name) {{{1
-"bookmark this node with a:name
+" FUNCTION: TreeFileNode.bookmark(name) {{{1
+" bookmark this node with a:name
 function! s:TreeFileNode.bookmark(name)
 
-    "if a bookmark exists with the same name and the node is cached then save
-    "it so we can update its display string
+    " if a bookmark exists with the same name and the node is cached then save
+    " it so we can update its display string
     let oldMarkedNode = {}
     try
         let oldMarkedNode = g:NERDTreeBookmark.GetNodeForName(a:name, 1, self.getNerdtree())
@@ -33,8 +36,8 @@ function! s:TreeFileNode.bookmark(name)
     endif
 endfunction
 
-"FUNCTION: TreeFileNode.cacheParent() {{{1
-"initializes self.parent if it isnt already
+" FUNCTION: TreeFileNode.cacheParent() {{{1
+" initializes self.parent if it isnt already
 function! s:TreeFileNode.cacheParent()
     if empty(self.parent)
         let parentPath = self.path.getParent()
@@ -45,7 +48,7 @@ function! s:TreeFileNode.cacheParent()
     endif
 endfunction
 
-"FUNCTION: TreeFileNode.clearBookmarks() {{{1
+" FUNCTION: TreeFileNode.clearBookmarks() {{{1
 function! s:TreeFileNode.clearBookmarks()
     for i in g:NERDTreeBookmark.Bookmarks()
         if i.path.equals(self.path)
@@ -55,7 +58,7 @@ function! s:TreeFileNode.clearBookmarks()
     call self.path.cacheDisplayString()
 endfunction
 
-"FUNCTION: TreeFileNode.copy(dest) {{{1
+" FUNCTION: TreeFileNode.copy(dest) {{{1
 function! s:TreeFileNode.copy(dest)
     call self.path.copy(a:dest)
     let newPath = g:NERDTreePath.New(a:dest)
@@ -68,44 +71,44 @@ function! s:TreeFileNode.copy(dest)
     endif
 endfunction
 
-"FUNCTION: TreeFileNode.delete {{{1
-"Removes this node from the tree and calls the Delete method for its path obj
+" FUNCTION: TreeFileNode.delete {{{1
+" Removes this node from the tree and calls the Delete method for its path obj
 function! s:TreeFileNode.delete()
     call self.path.delete()
     call self.parent.removeChild(self)
 endfunction
 
-"FUNCTION: TreeFileNode.displayString() {{{1
+" FUNCTION: TreeFileNode.displayString() {{{1
 "
-"Returns a string that specifies how the node should be represented as a
-"string
+" Returns a string that specifies how the node should be represented as a
+" string
 "
-"Return:
-"a string that can be used in the view to represent this node
+" Return:
+" a string that can be used in the view to represent this node
 function! s:TreeFileNode.displayString()
     return self.path.flagSet.renderToString() . self.path.displayString()
 endfunction
 
-"FUNCTION: TreeFileNode.equals(treenode) {{{1
+" FUNCTION: TreeFileNode.equals(treenode) {{{1
 "
-"Compares this treenode to the input treenode and returns 1 if they are the
-"same node.
+" Compares this treenode to the input treenode and returns 1 if they are the
+" same node.
 "
-"Use this method instead of ==  because sometimes when the treenodes contain
-"many children, vim seg faults when doing ==
+" Use this method instead of ==  because sometimes when the treenodes contain
+" many children, vim seg faults when doing ==
 "
-"Args:
-"treenode: the other treenode to compare to
+" Args:
+" treenode: the other treenode to compare to
 function! s:TreeFileNode.equals(treenode)
     return self.path.str() ==# a:treenode.path.str()
 endfunction
 
-"FUNCTION: TreeFileNode.findNode(path) {{{1
-"Returns self if this node.path.Equals the given path.
-"Returns {} if not equal.
+" FUNCTION: TreeFileNode.findNode(path) {{{1
+" Returns self if this node.path.Equals the given path.
+" Returns {} if not equal.
 "
-"Args:
-"path: the path object to compare against
+" Args:
+" path: the path object to compare against
 function! s:TreeFileNode.findNode(path)
     if a:path.equals(self.path)
         return self
@@ -113,18 +116,18 @@ function! s:TreeFileNode.findNode(path)
     return {}
 endfunction
 
-"FUNCTION: TreeFileNode.findOpenDirSiblingWithVisibleChildren(direction) {{{1
+" FUNCTION: TreeFileNode.findOpenDirSiblingWithVisibleChildren(direction) {{{1
 "
-"Finds the next sibling for this node in the indicated direction. This sibling
-"must be a directory and may/may not have children as specified.
+" Finds the next sibling for this node in the indicated direction. This sibling
+" must be a directory and may/may not have children as specified.
 "
-"Args:
-"direction: 0 if you want to find the previous sibling, 1 for the next sibling
+" Args:
+" direction: 0 if you want to find the previous sibling, 1 for the next sibling
 "
-"Return:
-"a treenode object or {} if no appropriate sibling could be found
+" Return:
+" a treenode object or {} if no appropriate sibling could be found
 function! s:TreeFileNode.findOpenDirSiblingWithVisibleChildren(direction)
-    "if we have no parent then we can have no siblings
+    " if we have no parent then we can have no siblings
     if self.parent != {}
         let nextSibling = self.findSibling(a:direction)
 
@@ -139,37 +142,37 @@ function! s:TreeFileNode.findOpenDirSiblingWithVisibleChildren(direction)
     return {}
 endfunction
 
-"FUNCTION: TreeFileNode.findSibling(direction) {{{1
+" FUNCTION: TreeFileNode.findSibling(direction) {{{1
 "
-"Finds the next sibling for this node in the indicated direction
+" Finds the next sibling for this node in the indicated direction
 "
-"Args:
-"direction: 0 if you want to find the previous sibling, 1 for the next sibling
+" Args:
+" direction: 0 if you want to find the previous sibling, 1 for the next sibling
 "
-"Return:
-"a treenode object or {} if no sibling could be found
+" Return:
+" a treenode object or {} if no sibling could be found
 function! s:TreeFileNode.findSibling(direction)
-    "if we have no parent then we can have no siblings
+    " if we have no parent then we can have no siblings
     if self.parent != {}
 
-        "get the index of this node in its parents children
+        " get the index of this node in its parents children
         let siblingIndx = self.parent.getChildIndex(self.path)
 
         if siblingIndx != -1
-            "move a long to the next potential sibling node
+            " move a long to the next potential sibling node
             let siblingIndx = a:direction ==# 1 ? siblingIndx+1 : siblingIndx-1
 
-            "keep moving along to the next sibling till we find one that is valid
+            " keep moving along to the next sibling till we find one that is valid
             let numSiblings = self.parent.getChildCount()
             while siblingIndx >= 0 && siblingIndx < numSiblings
 
-                "if the next node is not an ignored node (i.e. wont show up in the
-                "view) then return it
+                " if the next node is not an ignored node (i.e. wont show up in the
+                " view) then return it
                 if self.parent.children[siblingIndx].path.ignore(self.getNerdtree()) ==# 0
                     return self.parent.children[siblingIndx]
                 endif
 
-                "go to next node
+                " go to next node
                 let siblingIndx = a:direction ==# 1 ? siblingIndx+1 : siblingIndx-1
             endwhile
         endif
@@ -178,13 +181,13 @@ function! s:TreeFileNode.findSibling(direction)
     return {}
 endfunction
 
-"FUNCTION: TreeFileNode.getNerdtree(){{{1
+" FUNCTION: TreeFileNode.getNerdtree(){{{1
 function! s:TreeFileNode.getNerdtree()
     return self._nerdtree
 endfunction
 
-"FUNCTION: TreeFileNode.GetRootForTab(){{{1
-"get the root node for this tab
+" FUNCTION: TreeFileNode.GetRootForTab(){{{1
+" get the root node for this tab
 function! s:TreeFileNode.GetRootForTab()
     if g:NERDTree.ExistsForTab()
         return getbufvar(t:NERDTreeBufName, 'NERDTree').root
@@ -192,8 +195,8 @@ function! s:TreeFileNode.GetRootForTab()
     return {}
 endfunction
 
-"FUNCTION: TreeFileNode.GetSelected() {{{1
-"gets the treenode that the cursor is currently over
+" FUNCTION: TreeFileNode.GetSelected() {{{1
+" gets the treenode that the cursor is currently over
 function! s:TreeFileNode.GetSelected()
     try
         let path = b:NERDTree.ui.getPath(line("."))
@@ -206,14 +209,14 @@ function! s:TreeFileNode.GetSelected()
     endtry
 endfunction
 
-"FUNCTION: TreeFileNode.isVisible() {{{1
-"returns 1 if this node should be visible according to the tree filters and
-"hidden file filters (and their on/off status)
+" FUNCTION: TreeFileNode.isVisible() {{{1
+" returns 1 if this node should be visible according to the tree filters and
+" hidden file filters (and their on/off status)
 function! s:TreeFileNode.isVisible()
     return !self.path.ignore(self.getNerdtree())
 endfunction
 
-"FUNCTION: TreeFileNode.isRoot() {{{1
+" FUNCTION: TreeFileNode.isRoot() {{{1
 function! s:TreeFileNode.isRoot()
     if !g:NERDTree.ExistsForBuf()
         throw "NERDTree.NoTreeError: No tree exists for the current buffer"
@@ -222,12 +225,12 @@ function! s:TreeFileNode.isRoot()
     return self.equals(self.getNerdtree().root)
 endfunction
 
-"FUNCTION: TreeFileNode.New(path, nerdtree) {{{1
-"Returns a new TreeNode object with the given path and parent
+" FUNCTION: TreeFileNode.New(path, nerdtree) {{{1
+" Returns a new TreeNode object with the given path and parent
 "
-"Args:
-"path: file/dir that the node represents
-"nerdtree: the tree the node belongs to
+" Args:
+" path: file/dir that the node represents
+" nerdtree: the tree the node belongs to
 function! s:TreeFileNode.New(path, nerdtree)
     if a:path.isDirectory
         return g:NERDTreeDirNode.New(a:path, a:nerdtree)
@@ -240,40 +243,40 @@ function! s:TreeFileNode.New(path, nerdtree)
     endif
 endfunction
 
-"FUNCTION: TreeFileNode.open() {{{1
+" FUNCTION: TreeFileNode.open() {{{1
 function! s:TreeFileNode.open(...)
     let opts = a:0 ? a:1 : {}
     let opener = g:NERDTreeOpener.New(self.path, opts)
     call opener.open(self)
 endfunction
 
-"FUNCTION: TreeFileNode.openSplit() {{{1
-"Open this node in a new window
+" FUNCTION: TreeFileNode.openSplit() {{{1
+" Open this node in a new window
 function! s:TreeFileNode.openSplit()
     call nerdtree#deprecated('TreeFileNode.openSplit', 'is deprecated, use .open() instead.')
     call self.open({'where': 'h'})
 endfunction
 
-"FUNCTION: TreeFileNode.openVSplit() {{{1
-"Open this node in a new vertical window
+" FUNCTION: TreeFileNode.openVSplit() {{{1
+" Open this node in a new vertical window
 function! s:TreeFileNode.openVSplit()
     call nerdtree#deprecated('TreeFileNode.openVSplit', 'is deprecated, use .open() instead.')
     call self.open({'where': 'v'})
 endfunction
 
-"FUNCTION: TreeFileNode.openInNewTab(options) {{{1
+" FUNCTION: TreeFileNode.openInNewTab(options) {{{1
 function! s:TreeFileNode.openInNewTab(options)
     echomsg 'TreeFileNode.openInNewTab is deprecated'
     call self.open(extend({'where': 't'}, a:options))
 endfunction
 
-"FUNCTION: TreeFileNode.putCursorHere(isJump, recurseUpward){{{1
-"Places the cursor on the line number this node is rendered on
+" FUNCTION: TreeFileNode.putCursorHere(isJump, recurseUpward){{{1
+" Places the cursor on the line number this node is rendered on
 "
-"Args:
-"isJump: 1 if this cursor movement should be counted as a jump by vim
-"recurseUpward: try to put the cursor on the parent if the this node isnt
-"visible
+" Args:
+" isJump: 1 if this cursor movement should be counted as a jump by vim
+" recurseUpward: try to put the cursor on the parent if the this node isnt
+" visible
 function! s:TreeFileNode.putCursorHere(isJump, recurseUpward)
     let ln = self.getNerdtree().ui.getLineNum(self)
     if ln != -1
@@ -294,18 +297,18 @@ function! s:TreeFileNode.putCursorHere(isJump, recurseUpward)
     endif
 endfunction
 
-"FUNCTION: TreeFileNode.refresh() {{{1
+" FUNCTION: TreeFileNode.refresh() {{{1
 function! s:TreeFileNode.refresh()
     call self.path.refresh(self.getNerdtree())
 endfunction
 
-"FUNCTION: TreeFileNode.refreshFlags() {{{1
+" FUNCTION: TreeFileNode.refreshFlags() {{{1
 function! s:TreeFileNode.refreshFlags()
     call self.path.refreshFlags(self.getNerdtree())
 endfunction
 
-"FUNCTION: TreeFileNode.rename() {{{1
-"Calls the rename method for this nodes path obj
+" FUNCTION: TreeFileNode.rename() {{{1
+" Calls the rename method for this nodes path obj
 function! s:TreeFileNode.rename(newName)
     let newName = substitute(a:newName, '\(\\\|\/\)$', '', '')
     call self.path.rename(newName)
@@ -320,17 +323,17 @@ function! s:TreeFileNode.rename(newName)
     endif
 endfunction
 
-"FUNCTION: TreeFileNode.renderToString {{{1
-"returns a string representation for this tree to be rendered in the view
+" FUNCTION: TreeFileNode.renderToString {{{1
+" returns a string representation for this tree to be rendered in the view
 function! s:TreeFileNode.renderToString()
     return self._renderToString(0, 0)
 endfunction
 
-"Args:
-"depth: the current depth in the tree for this call
-"drawText: 1 if we should actually draw the line for this node (if 0 then the
-"child nodes are rendered only)
-"for each depth in the tree
+" Args:
+" depth: the current depth in the tree for this call
+" drawText: 1 if we should actually draw the line for this node (if 0 then the
+" child nodes are rendered only)
+" for each depth in the tree
 function! s:TreeFileNode._renderToString(depth, drawText)
     let output = ""
     if a:drawText ==# 1
@@ -346,7 +349,7 @@ function! s:TreeFileNode._renderToString(depth, drawText)
         let output = output . line . "\n"
     endif
 
-    "if the node is an open dir, draw its children
+    " if the node is an open dir, draw its children
     if self.path.isDirectory ==# 1 && self.isOpen ==# 1
 
         let childNodesToDraw = self.getVisibleChildren()

--- a/lib/nerdtree/ui.vim
+++ b/lib/nerdtree/ui.vim
@@ -1,11 +1,14 @@
-"CLASS: UI
-"============================================================
+" ============================================================================
+" CLASS: UI
+" ============================================================================
+
+
 let s:UI = {}
 let g:NERDTreeUI = s:UI
 
-"FUNCTION: s:UI.centerView() {{{2
-"centers the nerd tree window around the cursor (provided the nerd tree
-"options permit)
+" FUNCTION: s:UI.centerView() {{{2
+" centers the nerd tree window around the cursor (provided the nerd tree
+" options permit)
 function! s:UI.centerView()
     if g:NERDTreeAutoCenter
         let current_line = winline()
@@ -17,8 +20,8 @@ function! s:UI.centerView()
     endif
 endfunction
 
-"FUNCTION: s:UI._dumpHelp  {{{1
-"prints out the quick help
+" FUNCTION: s:UI._dumpHelp  {{{1
+" prints out the quick help
 function! s:UI._dumpHelp()
     if self.getShowHelp()
         let help  = "\" NERDTree (" . nerdtree#version() . ") quickhelp~\n"
@@ -93,7 +96,7 @@ function! s:UI._dumpHelp()
         let help .= "\" ". g:NERDTreeMapToggleFiles .": files (" . (self.getShowFiles() ? "on" : "off") . ")\n"
         let help .= "\" ". g:NERDTreeMapToggleBookmarks .": bookmarks (" . (self.getShowBookmarks() ? "on" : "off") . ")\n"
 
-        "add quickhelp entries for each custom key map
+        " add quickhelp entries for each custom key map
         let help .= "\"\n\" ----------------------------\n"
         let help .= "\" Custom mappings~\n"
         for i in g:NERDTreeKeyMap.All()
@@ -124,7 +127,7 @@ function! s:UI._dumpHelp()
 endfunction
 
 
-"FUNCTION: s:UI.new(nerdtree) {{{1
+" FUNCTION: s:UI.new(nerdtree) {{{1
 function! s:UI.New(nerdtree)
     let newObj = copy(self)
     let newObj.nerdtree = a:nerdtree
@@ -137,22 +140,22 @@ function! s:UI.New(nerdtree)
     return newObj
 endfunction
 
-"FUNCTION: s:UI.getPath(ln) {{{1
-"Gets the full path to the node that is rendered on the given line number
+" FUNCTION: s:UI.getPath(ln) {{{1
+" Gets the full path to the node that is rendered on the given line number
 "
-"Args:
-"ln: the line number to get the path for
+" Args:
+" ln: the line number to get the path for
 "
-"Return:
-"A path if a node was selected, {} if nothing is selected.
-"If the 'up a dir' line was selected then the path to the parent of the
-"current root is returned
+" Return:
+" A path if a node was selected, {} if nothing is selected.
+" If the 'up a dir' line was selected then the path to the parent of the
+" current root is returned
 function! s:UI.getPath(ln)
     let line = getline(a:ln)
 
     let rootLine = self.getRootLineNum()
 
-    "check to see if we have the root node
+    " check to see if we have the root node
     if a:ln == rootLine
         return self.nerdtree.root.path
     endif
@@ -163,7 +166,7 @@ function! s:UI.getPath(ln)
 
     let indent = self._indentLevelFor(line)
 
-    "remove the tree parts and the leading space
+    " remove the tree parts and the leading space
     let curFile = self._stripMarkup(line)
 
     let dir = ""
@@ -173,7 +176,7 @@ function! s:UI.getPath(ln)
         let curLine = getline(lnum)
         let curLineStripped = self._stripMarkup(curLine)
 
-        "have we reached the top of the tree?
+        " have we reached the top of the tree?
         if lnum == rootLine
             let dir = self.nerdtree.root.path.str({'format': 'UI'}) . dir
             break
@@ -193,19 +196,19 @@ function! s:UI.getPath(ln)
     return toReturn
 endfunction
 
-"FUNCTION: s:UI.getLineNum(file_node){{{1
-"returns the line number this node is rendered on, or -1 if it isnt rendered
+" FUNCTION: s:UI.getLineNum(file_node){{{1
+" returns the line number this node is rendered on, or -1 if it isnt rendered
 function! s:UI.getLineNum(file_node)
-    "if the node is the root then return the root line no.
+    " if the node is the root then return the root line no.
     if a:file_node.isRoot()
         return self.getRootLineNum()
     endif
 
     let totalLines = line("$")
 
-    "the path components we have matched so far
+    " the path components we have matched so far
     let pathcomponents = [substitute(self.nerdtree.root.path.str({'format': 'UI'}), '/ *$', '', '')]
-    "the index of the component we are searching for
+    " the index of the component we are searching for
     let curPathComponent = 1
 
     let fullpath = a:file_node.path.str({'format': 'UI'})
@@ -213,7 +216,7 @@ function! s:UI.getLineNum(file_node)
     let lnum = self.getRootLineNum()
     while lnum > 0
         let lnum = lnum + 1
-        "have we reached the bottom of the tree?
+        " have we reached the bottom of the tree?
         if lnum ==# totalLines+1
             return -1
         endif
@@ -241,8 +244,8 @@ function! s:UI.getLineNum(file_node)
     return -1
 endfunction
 
-"FUNCTION: s:UI.getRootLineNum(){{{1
-"gets the line number of the root node
+" FUNCTION: s:UI.getRootLineNum(){{{1
+" gets the line number of the root node
 function! s:UI.getRootLineNum()
     let rootLine = 1
     while getline(rootLine) !~# '^\(/\|<\)'
@@ -251,29 +254,29 @@ function! s:UI.getRootLineNum()
     return rootLine
 endfunction
 
-"FUNCTION: s:UI.getShowBookmarks() {{{1
+" FUNCTION: s:UI.getShowBookmarks() {{{1
 function! s:UI.getShowBookmarks()
     return self._showBookmarks
 endfunction
 
-"FUNCTION: s:UI.getShowFiles() {{{1
+" FUNCTION: s:UI.getShowFiles() {{{1
 function! s:UI.getShowFiles()
     return self._showFiles
 endfunction
 
-"FUNCTION: s:UI.getShowHelp() {{{1
+" FUNCTION: s:UI.getShowHelp() {{{1
 function! s:UI.getShowHelp()
     return self._showHelp
 endfunction
 
-"FUNCTION: s:UI.getShowHidden() {{{1
+" FUNCTION: s:UI.getShowHidden() {{{1
 function! s:UI.getShowHidden()
     return self._showHidden
 endfunction
 
-"FUNCTION: s:UI._indentLevelFor(line) {{{1
+" FUNCTION: s:UI._indentLevelFor(line) {{{1
 function! s:UI._indentLevelFor(line)
-    "have to do this work around because match() returns bytes, not chars
+    " have to do this work around because match() returns bytes, not chars
     let numLeadBytes = match(a:line, '\M\[^ '.g:NERDTreeDirArrowExpandable.g:NERDTreeDirArrowCollapsible.']')
     " The next line is a backward-compatible workaround for strchars(a:line(0:numLeadBytes-1]). strchars() is in 7.3+
     let leadChars = len(split(a:line[0:numLeadBytes-1], '\zs'))
@@ -281,27 +284,27 @@ function! s:UI._indentLevelFor(line)
     return leadChars / s:UI.IndentWid()
 endfunction
 
-"FUNCTION: s:UI.IndentWid() {{{1
+" FUNCTION: s:UI.IndentWid() {{{1
 function! s:UI.IndentWid()
     return 2
 endfunction
 
-"FUNCTION: s:UI.isIgnoreFilterEnabled() {{{1
+" FUNCTION: s:UI.isIgnoreFilterEnabled() {{{1
 function! s:UI.isIgnoreFilterEnabled()
     return self._ignoreEnabled == 1
 endfunction
 
-"FUNCTION: s:UI.isMinimal() {{{1
+" FUNCTION: s:UI.isMinimal() {{{1
 function! s:UI.isMinimal()
     return g:NERDTreeMinimalUI
 endfunction
 
-"FUNCTION: s:UI.MarkupReg() {{{1
+" FUNCTION: s:UI.MarkupReg() {{{1
 function! s:UI.MarkupReg()
     return '^\(['.g:NERDTreeDirArrowExpandable.g:NERDTreeDirArrowCollapsible.'] \| \+['.g:NERDTreeDirArrowExpandable.g:NERDTreeDirArrowCollapsible.'] \| \+\)'
 endfunction
 
-"FUNCTION: s:UI._renderBookmarks {{{1
+" FUNCTION: s:UI._renderBookmarks {{{1
 function! s:UI._renderBookmarks()
 
     if !self.isMinimal()
@@ -322,12 +325,12 @@ function! s:UI._renderBookmarks()
     call cursor(line(".")+1, col("."))
 endfunction
 
-"FUNCTION: s:UI.restoreScreenState() {{{1
+" FUNCTION: s:UI.restoreScreenState() {{{1
 "
-"Sets the screen state back to what it was when nerdtree#saveScreenState was last
-"called.
+" Sets the screen state back to what it was when nerdtree#saveScreenState was last
+" called.
 "
-"Assumes the cursor is in the NERDTree window
+" Assumes the cursor is in the NERDTree window
 function! s:UI.restoreScreenState()
     if !has_key(self, '_screenState')
         return
@@ -342,9 +345,9 @@ function! s:UI.restoreScreenState()
     let &scrolloff=old_scrolloff
 endfunction
 
-"FUNCTION: s:UI.saveScreenState() {{{1
-"Saves the current cursor position in the current buffer and the window
-"scroll position
+" FUNCTION: s:UI.saveScreenState() {{{1
+" Saves the current cursor position in the current buffer and the window
+" scroll position
 function! s:UI.saveScreenState()
     let win = winnr()
     call g:NERDTree.CursorToTreeWin()
@@ -355,31 +358,31 @@ function! s:UI.saveScreenState()
     call nerdtree#exec(win . "wincmd w")
 endfunction
 
-"FUNCTION: s:UI.setShowHidden(val) {{{1
+" FUNCTION: s:UI.setShowHidden(val) {{{1
 function! s:UI.setShowHidden(val)
     let self._showHidden = a:val
 endfunction
 
-"FUNCTION: s:UI._stripMarkup(line){{{1
-"returns the given line with all the tree parts stripped off
+" FUNCTION: s:UI._stripMarkup(line){{{1
+" returns the given line with all the tree parts stripped off
 "
-"Args:
-"line: the subject line
+" Args:
+" line: the subject line
 function! s:UI._stripMarkup(line)
     let line = a:line
-    "remove the tree parts and the leading space
+    " remove the tree parts and the leading space
     let line = substitute (line, g:NERDTreeUI.MarkupReg(),"","")
 
-    "strip off any read only flag
+    " strip off any read only flag
     let line = substitute (line, ' \['.g:NERDTreeGlyphReadOnly.'\]', "","")
 
-    "strip off any bookmark flags
+    " strip off any bookmark flags
     let line = substitute (line, ' {[^}]*}', "","")
 
-    "strip off any executable flags
+    " strip off any executable flags
     let line = substitute (line, '*\ze\($\| \)', "","")
 
-    "strip off any generic flags
+    " strip off any generic flags
     let line = substitute (line, '\[[^]]*\]', "","")
 
     let line = substitute (line,' -> .*',"","") " remove link to
@@ -387,22 +390,22 @@ function! s:UI._stripMarkup(line)
     return line
 endfunction
 
-"FUNCTION: s:UI.render() {{{1
+" FUNCTION: s:UI.render() {{{1
 function! s:UI.render()
     setlocal modifiable
 
-    "remember the top line of the buffer and the current line so we can
-    "restore the view exactly how it was
+    " remember the top line of the buffer and the current line so we can
+    " restore the view exactly how it was
     let curLine = line(".")
     let curCol = col(".")
     let topLine = line("w0")
 
-    "delete all lines in the buffer (being careful not to clobber a register)
+    " delete all lines in the buffer (being careful not to clobber a register)
     silent 1,$delete _
 
     call self._dumpHelp()
 
-    "delete the blank line before the help and add one after it
+    " delete the blank line before the help and add one after it
     if !self.isMinimal()
         call setline(line(".")+1, "")
         call cursor(line(".")+1, col("."))
@@ -412,24 +415,24 @@ function! s:UI.render()
         call self._renderBookmarks()
     endif
 
-    "add the 'up a dir' line
+    " add the 'up a dir' line
     if !self.isMinimal()
         call setline(line(".")+1, s:UI.UpDirLine())
         call cursor(line(".")+1, col("."))
     endif
 
-    "draw the header line
+    " draw the header line
     let header = self.nerdtree.root.path.str({'format': 'UI', 'truncateTo': winwidth(0)})
     call setline(line(".")+1, header)
     call cursor(line(".")+1, col("."))
 
-    "draw the tree
+    " draw the tree
     silent put =self.nerdtree.root.renderToString()
 
-    "delete the blank line at the top of the buffer
+    " delete the blank line at the top of the buffer
     silent 1,1delete _
 
-    "restore the view
+    " restore the view
     let old_scrolloff=&scrolloff
     let &scrolloff=0
     call cursor(topLine, 1)
@@ -441,14 +444,14 @@ function! s:UI.render()
 endfunction
 
 
-"FUNCTION: UI.renderViewSavingPosition {{{1
-"Renders the tree and ensures the cursor stays on the current node or the
-"current nodes parent if it is no longer available upon re-rendering
+" FUNCTION: UI.renderViewSavingPosition {{{1
+" Renders the tree and ensures the cursor stays on the current node or the
+" current nodes parent if it is no longer available upon re-rendering
 function! s:UI.renderViewSavingPosition()
     let currentNode = g:NERDTreeFileNode.GetSelected()
 
-    "go up the tree till we find a node that will be visible or till we run
-    "out of nodes
+    " go up the tree till we find a node that will be visible or till we run
+    " out of nodes
     while currentNode != {} && !currentNode.isVisible() && !currentNode.isRoot()
         let currentNode = currentNode.parent
     endwhile
@@ -460,7 +463,7 @@ function! s:UI.renderViewSavingPosition()
     endif
 endfunction
 
-"FUNCTION: s:UI.toggleHelp() {{{1
+" FUNCTION: s:UI.toggleHelp() {{{1
 function! s:UI.toggleHelp()
     let self._showHelp = !self._showHelp
 endfunction
@@ -515,7 +518,7 @@ function! s:UI.toggleZoom()
     endif
 endfunction
 
-"FUNCTION: s:UI.UpDirLine() {{{1
+" FUNCTION: s:UI.UpDirLine() {{{1
 function! s:UI.UpDirLine()
     return '.. (up a dir)'
 endfunction

--- a/lib/nerdtree/ui.vim
+++ b/lib/nerdtree/ui.vim
@@ -141,15 +141,10 @@ function! s:UI.New(nerdtree)
 endfunction
 
 " FUNCTION: s:UI.getPath(ln) {{{1
-" Gets the full path to the node that is rendered on the given line number
-"
-" Args:
-" ln: the line number to get the path for
-"
-" Return:
-" A path if a node was selected, {} if nothing is selected.
-" If the 'up a dir' line was selected then the path to the parent of the
-" current root is returned
+" Return the "Path" object for the node that is rendered on the given line
+" number.  If the "up a dir" line is selected, return the "Path" object for
+" the parent of the root.  Return the empty dictionary if the given line
+" does not reference a tree node.
 function! s:UI.getPath(ln)
     let line = getline(a:ln)
 

--- a/lib/nerdtree/ui.vim
+++ b/lib/nerdtree/ui.vim
@@ -150,7 +150,6 @@ function! s:UI.getPath(ln)
 
     let rootLine = self.getRootLineNum()
 
-    " check to see if we have the root node
     if a:ln == rootLine
         return self.nerdtree.root.path
     endif

--- a/lib/nerdtree/ui.vim
+++ b/lib/nerdtree/ui.vim
@@ -158,6 +158,10 @@ function! s:UI.getPath(ln)
         return self.nerdtree.root.path.getParent()
     endif
 
+    if a:ln < rootLine
+        return {}
+    endif
+
     let indent = self._indentLevelFor(line)
 
     " remove the tree parts and the leading space


### PR DESCRIPTION
In addition to a number of style improvements, this PR fixes some unstable behavior for the `NERDTreeUI.getPath()` method.

To replicate the problem on *nix systems:

1. Open Vim, then open the NERDTree.
2. Position cursor on blank line above tree.
3. Run `:echo b:NERDTree.ui.getPath(line('.'))` to see that the wrong value is returned (this only works if the working directory is at or beneath the NERDTree root).

This problem doesn't exist on Windows from what I can tell.

