### PR TITLE
Fix focussing previous buffer when closing NERDTree

### DIFF
--- a/lib/nerdtree/nerdtree.vim
+++ b/lib/nerdtree/nerdtree.vim
@@ -38,17 +38,26 @@ function! s:NERDTree.Close()
     endif
 
     if winnr("$") != 1
+        " Use the window ID to identify the currently active window or fall
+        " back on the buffer ID if win_getid/win_gotoid are not available, in
+        " which case we'll focus an arbitrary window showing the buffer.
+        let l:useWinId = exists('*win_getid') && exists('*win_gotoid')
+
         if winnr() == s:NERDTree.GetWinNum()
             call nerdtree#exec("wincmd p")
-            let bufnr = bufnr("")
+            let l:activeBufOrWin = l:useWinId ? win_getid() : bufnr("")
             call nerdtree#exec("wincmd p")
         else
-            let bufnr = bufnr("")
+            let l:activeBufOrWin = l:useWinId ? win_getid() : bufnr("")
         endif
 
         call nerdtree#exec(s:NERDTree.GetWinNum() . " wincmd w")
         close
-        call nerdtree#exec(bufwinnr(bufnr) . " wincmd w")
+        if l:useWinId
+            call nerdtree#exec("call win_gotoid(" . l:activeBufOrWin . ")")
+        else
+            call nerdtree#exec(bufwinnr(l:activeBufOrWin) . " wincmd w")
+        endif
     else
         close
     endif


### PR DESCRIPTION
Previously closing NERDTree while two windows were showing the same buffer would
focus the first window, which was not necessarily the previously active one.

Instead of obtaining the buffer ID of the previous buffer and mapping that to
the window ID (which is a 1:n mapping) we obtain the unique window ID and focus
the right window after closing NERDTree.

win_getid() and win_gotoid() are available from VIM 7.4.1557, so this patch is
conditional on that version.