### PR TITLE
Use Choosewin on Open File

### DIFF
--- a/autoload/nerdtree/ui_glue.vim
+++ b/autoload/nerdtree/ui_glue.vim
@@ -104,6 +104,9 @@ endfunction
 "FUNCTION: s:activateFileNode() {{{1
 "handle the user activating a tree node
 function! s:activateFileNode(node)
+    let l:nerdwindow = win_getid()
+    call choosewin#start(range(1, winnr('$')))
+    call win_gotoid(l:nerdwindow)
     call a:node.activate({'reuse': 'all', 'where': 'p'})
 endfunction
 

--- a/autoload/nerdtree/ui_glue.vim
+++ b/autoload/nerdtree/ui_glue.vim
@@ -104,9 +104,16 @@ endfunction
 "FUNCTION: s:activateFileNode() {{{1
 "handle the user activating a tree node
 function! s:activateFileNode(node)
-    let l:nerdwindow = win_getid()
-    call choosewin#start(range(1, winnr('$')))
-    call win_gotoid(l:nerdwindow)
+    " Select the window where to open the file, if the 'choosewin' plugin is
+    " in the runtime path.
+    " It is necessary to jump back the NERDTree window, cause local buffer
+    " variables are required for the following procedure.
+    if &rtp =~ 'vim-choosewin'
+        let l:nerdwindow = win_getid()
+        call choosewin#start(range(1, winnr('$')))
+        call win_gotoid(l:nerdwindow) 
+    endif
+
     call a:node.activate({'reuse': 'all', 'where': 'p'})
 endfunction
 


### PR DESCRIPTION
I like to use the [choosewin](https://github.com/t9md/vim-choosewin) plugin. And I found it useful to combine it with _NERDTree_ on open a file. Case when open a file from within _NERDTree_ straight forward, it choose the last active window to show the new buffer. Often I've open multiple windows and rly wanna specify in which one the buffer should been opened.

With this simple adjustment this is possible. If the plugin can be found by name in the runtime path, the `activateFileNode()` function first call _choosewin_, so the user can select a window.<br>
Cause the following procedure in _NERDTree_ use local buffer variabels, it was necessary to backup the window ID of the _NERDTree_ window and jump back to it, after the user has choosen the window.

Despite _choosewin_ hasn't that much stars (if that is an indicator), this new functionality should do not bother anyone, cause it only works for these, which have installed this additional plugin. And I guess these will love it.

Maybe the README can be adjusted to promote this relation to _choosewin_.