### PR TITLE
Use a better check for existence of the NERDTree buffer.

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,37 +1,30 @@
-_To assist in resolving your issue, provide as much information as possible, in place of the ellipses (`…`) below._
+<!--- To assist in resolving your issue, provide as much information as possible. -->
 
----
-**Environment:** _Describe your Vim/NERDTree setup._
+### Environment
+<!--- Describe your Vim/NERDTree setup. -->
 
->* Operating System: …
->* Vim version `:version`: …
->* NERDTree version `git rev-parse --short HEAD`: …
->* NERDTree settings applied in your vimrc, if any:
->
->   ```
->   …
->   ```
+* Operating System: 
+* Vim version `:version`: 
+* NERDTree version `git rev-parse --short HEAD`: 
+* NERDTree settings applied in your vimrc, if any:
+    ```vim
+    ```
 
-**Process:** _List the steps that will recreate the issue._
+### Process
+<!--- List the steps that will recreate the issue. -->
 
->1. …
+1. 
 
-**Current Result:** _Describe what you you currently experience from this process._
+### Current Result
+<!--- Describe what you you currently experience from this process. -->
 
->…
+### Expected Result
+<!--- Describe what you would have expected from this process. -->
 
-**Expected Result:** _Describe what you would expect to have resulted from this process._
+## Optional
 
->…
+### Screenshot(s)
 
----
-**Optional**
-
-**Screenshot(s):**
-
->…
-
-**Possible Fix:** _(Have you poked around in the code?)_
-
->…
+### Possible Fix
+<!--- If you have explored the code, share what you've found. -->
 

--- a/lib/nerdtree/creator.vim
+++ b/lib/nerdtree/creator.vim
@@ -185,7 +185,7 @@ function! s:Creator._createTreeWin()
     let splitLocation = g:NERDTreeWinPos ==# "left" ? "topleft " : "botright "
     let splitSize = g:NERDTreeWinSize
 
-    if !exists('t:NERDTreeBufName')
+    if !g:NERDTree.ExistsForTab()
         let t:NERDTreeBufName = self._nextBufferName()
         silent! exec splitLocation . 'vertical ' . splitSize . ' new'
         silent! exec "edit " . t:NERDTreeBufName


### PR DESCRIPTION
Fixes #813.

If the user wipes out or deletes (:bw or :bd) the NERDTree buffer, there
is still a tab variable that hangs onto the name of that now-missing
buffer. Checking only that variable is not enough to decide whether to
create a new NERDTree or use the existing one. Fortunately, there
already is a function with a more complete check: `ExistsForTab()`