### PR TITLE
If node isn't open, count children on disk before deleting.

### DIFF
--- a/nerdtree_plugin/fs_menu.vim
+++ b/nerdtree_plugin/fs_menu.vim
@@ -175,7 +175,8 @@ function! NERDTreeDeleteNode()
     let currentNode = g:NERDTreeFileNode.GetSelected()
     let confirmed = 0
 
-    if currentNode.path.isDirectory && currentNode.getChildCount() > 0
+    if currentNode.path.isDirectory && ((currentNode.isOpen && currentNode.getChildCount() > 0) ||
+                                      \ (len(currentNode._glob('*', 1)) > 0))
         let choice =input("Delete the current node\n" .
                          \ "==========================================================\n" .
                          \ "STOP! Directory is not empty! To delete, type 'yes'\n" .


### PR DESCRIPTION
Fixes #821. If a node isn't opened in NERDTree, it's children aren't
known yet, so when deleting the node (with `m`, `d`), the user isn't
properly asked to confirm the delete. It was going to the less strict
`Y`/`n` confirmation, instead of the `yes` confirmation for non-empty
directories.

This change checks to see if the node is opened already. If it is, the
existing getChildCount() function is used; otherwise, the disk is read
to get the number of children there.