### PR TITLE
Clear output when NERDTree menu is aborted

### DIFF
--- a/lib/nerdtree/menu_controller.vim
+++ b/lib/nerdtree/menu_controller.vim
@@ -15,9 +15,9 @@ function! s:MenuController.New(menuItems)
     return newMenuController
 endfunction
 
-"FUNCTION: MenuController.showMenu() {{{1
-"start the main loop of the menu and get the user to choose/execute a menu
-"item
+" FUNCTION: MenuController.showMenu() {{{1
+" Enter the main loop of the NERDTree menu, prompting the user to select
+" a menu item.
 function! s:MenuController.showMenu()
     call self._saveOptions()
 

--- a/lib/nerdtree/menu_controller.vim
+++ b/lib/nerdtree/menu_controller.vim
@@ -33,6 +33,11 @@ function! s:MenuController.showMenu()
         endwhile
     finally
         call self._restoreOptions()
+
+        " Redraw when "Ctrl-C" or "Esc" is received.
+        if !l:done || self.selection == -1
+            redraw!
+        endif
     endtry
 
     if self.selection != -1

--- a/lib/nerdtree/menu_controller.vim
+++ b/lib/nerdtree/menu_controller.vim
@@ -23,13 +23,14 @@ function! s:MenuController.showMenu()
 
     try
         let self.selection = 0
+        let l:done = 0
 
-        let done = 0
-        while !done
+        while !l:done
             redraw!
             call self._echoPrompt()
-            let key = nr2char(getchar())
-            let done = self._handleKeypress(key)
+
+            let l:key = nr2char(getchar())
+            let l:done = self._handleKeypress(l:key)
         endwhile
     finally
         call self._restoreOptions()
@@ -41,8 +42,8 @@ function! s:MenuController.showMenu()
     endtry
 
     if self.selection != -1
-        let m = self._current()
-        call m.execute()
+        let l:m = self._current()
+        call l:m.execute()
     endif
 endfunction
 


### PR DESCRIPTION
See the commit messages for details.

Try `m<C-c>` or `m<Esc>` on a normal file or directory node to see the left-over output I'm talking about... 'tis quite annoying.