### PR TITLE
Fixed error 'unknown function strcharpart' for older versions of Vim

### DIFF
--- a/lib/nerdtree/bookmark.vim
+++ b/lib/nerdtree/bookmark.vim
@@ -287,10 +287,14 @@ function! s:Bookmark.str()
 
     let pathStr = self.path.str({'format': 'UI'})
     if strdisplaywidth(pathStr) > pathStrMaxLen
-        while strdisplaywidth(pathStr) > pathStrMaxLen && strchars(pathStr) > 0
-            let pathStr = strcharpart(pathStr, 1)
-        endwhile
-        let pathStr = '<' . pathStr
+        if exists("*strcharpart")
+            while strdisplaywidth(pathStr) > pathStrMaxLen && strchars(pathStr) > 0
+                let pathStr = strcharpart(pathStr, 1)
+            endwhile
+            let pathStr = '<' . pathStr
+        else
+            let pathStr = '<' . strpart(pathStr, len(pathStr) - pathStrMaxLen)
+        endif
     endif
     return '>' . self.name . ' ' . pathStr
 endfunction

--- a/lib/nerdtree/path.vim
+++ b/lib/nerdtree/path.vim
@@ -720,9 +720,13 @@ function! s:Path.str(...)
     if has_key(options, 'truncateTo')
         let limit = options['truncateTo']
         if strdisplaywidth(toReturn) > limit-1
-            while strdisplaywidth(toReturn) > limit-1 && strchars(toReturn) > 0
-                let toReturn = strcharpart(toReturn, 1)
-            endwhile
+            if exists("*strcharpart")
+                while strdisplaywidth(toReturn) > limit-1 && strchars(toReturn) > 0
+                    let toReturn = strcharpart(toReturn, 1)
+                endwhile
+            else
+                let toReturn = toReturn[(len(toReturn)-limit+1):]
+            endif
             if len(split(toReturn, '/')) > 1
                 let toReturn = '</' . join(split(toReturn, '/')[1:], '/') . '/'
             else


### PR DESCRIPTION
Previous commit ([`d3a7cd2`][prev]) resulted in a immediate crash when NERDTree is started, as shown in the screenshot below:

![screenshot](https://user-images.githubusercontent.com/19314925/39219953-8d16729a-4836-11e8-9a37-09aa2de44a1f.png)

This is due to the function `strcharpart()`, which has been added to vim in commit [vim/vim@`58de0e2`][vim] on April 14 2016 which is equivalent to the patch level 7.4.1730. One of the most popular operating systems, Ubuntu 16.04 LTS, is still using vim 7.4.1689, which doesn't have this function.

So I added backward-compatibility, by checking `if exists("*strcharpart")`

[prev]:https://github.com/scrooloose/nerdtree/commit/d3a7cd20aed896e62ca4fbcd44b8ebdf842d1adf
[vim]:https://github.com/vim/vim/commit/58de0e2dcc1f2d251b74892a06d71a14973f3187