### PR TITLE
Replace strcharpart() with substitute() for backward compatibility

### DIFF
--- a/lib/nerdtree/bookmark.vim
+++ b/lib/nerdtree/bookmark.vim
@@ -288,7 +288,7 @@ function! s:Bookmark.str()
     let pathStr = self.path.str({'format': 'UI'})
     if strdisplaywidth(pathStr) > pathStrMaxLen
         while strdisplaywidth(pathStr) > pathStrMaxLen && strchars(pathStr) > 0
-            let pathStr = strcharpart(pathStr, 1)
+            let pathStr = substitute(pathStr, '.\{1}', '', '')
         endwhile
         let pathStr = '<' . pathStr
     endif

--- a/lib/nerdtree/path.vim
+++ b/lib/nerdtree/path.vim
@@ -721,7 +721,7 @@ function! s:Path.str(...)
         let limit = options['truncateTo']
         if strdisplaywidth(toReturn) > limit-1
             while strdisplaywidth(toReturn) > limit-1 && strchars(toReturn) > 0
-                let toReturn = strcharpart(toReturn, 1)
+                let toReturn = substitute(toReturn, '.\{1}', '', '')
             endwhile
             if len(split(toReturn, '/')) > 1
                 let toReturn = '</' . join(split(toReturn, '/')[1:], '/') . '/'


### PR DESCRIPTION
Pull request #833 has supplied a fix to workaround the backward compatibility problem in #830.  But the multi-byte path problem will appear again in the older version of vim before the function strcharpart was introduced.  We can use substitute to achieve the same result as when strcharpart is used.