### PR TITLE
Make the NERDTree buffer writable when rendering it.

### DIFF
--- a/lib/nerdtree/ui.vim
+++ b/lib/nerdtree/ui.vim
@@ -390,7 +390,7 @@ endfunction
 
 " FUNCTION: s:UI.render() {{{1
 function! s:UI.render()
-    setlocal modifiable
+    setlocal noreadonly modifiable
 
     " remember the top line of the buffer and the current line so we can
     " restore the view exactly how it was
@@ -438,7 +438,7 @@ function! s:UI.render()
     call cursor(curLine, curCol)
     let &scrolloff = old_scrolloff
 
-    setlocal nomodifiable
+    setlocal readonly nomodifiable
 endfunction
 
 


### PR DESCRIPTION
Fixes #831.