### PR TITLE
Add an option to open NERDTree in current window

### DIFF
--- a/autoload/nerdtree.vim
+++ b/autoload/nerdtree.vim
@@ -10,40 +10,16 @@ endfunction
 " SECTION: General Functions {{{1
 "============================================================
 
-"FUNCTION: nerdtree#checkForBrowse(dir) {{{2
-"inits a window tree in the current buffer if appropriate
+" FUNCTION: nerdtree#checkForBrowse(dir) {{{2
+" inits a window tree in the current buffer if appropriate
 function! nerdtree#checkForBrowse(dir)
     if !isdirectory(a:dir)
         return
     endif
-
-    if s:reuseWin(a:dir)
-        return
-    endif
-
+    " wipe current directory buffer before opening NERDTree buffer
+    setlocal bufhidden=wipe
+    buffer #
     call g:NERDTreeCreator.CreateWindowTree(a:dir)
-endfunction
-
-"FUNCTION: s:reuseWin(dir) {{{2
-"finds a NERDTree buffer with root of dir, and opens it.
-function! s:reuseWin(dir) abort
-    let path = g:NERDTreePath.New(fnamemodify(a:dir, ":p"))
-
-    for i in range(1, bufnr("$"))
-        unlet! nt
-        let nt = getbufvar(i, "NERDTree")
-        if empty(nt)
-            continue
-        endif
-
-        if nt.isWinTree() && nt.root.path.equals(path)
-            call nt.setPreviousBuf(bufnr("#"))
-            exec "buffer " . i
-            return 1
-        endif
-    endfor
-
-    return 0
 endfunction
 
 " FUNCTION: nerdtree#completeBookmarks(A,L,P) {{{2

--- a/autoload/nerdtree/ui_glue.vim
+++ b/autoload/nerdtree/ui_glue.vim
@@ -270,7 +270,7 @@ function! s:findAndRevealPath(pathStr)
         return
     endtry
 
-    if !g:NERDTree.ExistsForTab()
+    if !g:NERDTree.ExistsForTab() && !g:NERDTreeUseCurrentWindow
         try
             let l:cwd = g:NERDTreePath.New(getcwd())
         catch /^NERDTree.InvalidArgumentsError/
@@ -569,14 +569,41 @@ endfunction
 
 " FUNCTION: nerdtree#ui_glue#setupCommands() {{{1
 function! nerdtree#ui_glue#setupCommands()
-    command! -n=? -complete=dir -bar NERDTree :call g:NERDTreeCreator.CreateTabTree('<args>')
-    command! -n=? -complete=dir -bar NERDTreeToggle :call g:NERDTreeCreator.ToggleTabTree('<args>')
-    command! -n=0 -bar NERDTreeClose :call g:NERDTree.Close()
-    command! -n=1 -complete=customlist,nerdtree#completeBookmarks -bar NERDTreeFromBookmark call g:NERDTreeCreator.CreateTabTree('<args>')
+    command! -n=? -complete=dir -bar NERDTree :call <SID>createTree('<args>')
+    command! -n=? -complete=dir -bar NERDTreeToggle :call <SID>toggleTree('<args>')
+    command! -n=0 -bar NERDTreeClose :call <SID>closeTree()
+    command! -n=1 -complete=customlist,nerdtree#completeBookmarks -bar NERDTreeFromBookmark call <SID>createTree('<args>')
     command! -n=0 -bar NERDTreeMirror call g:NERDTreeCreator.CreateMirror()
     command! -n=? -complete=file -bar NERDTreeFind call s:findAndRevealPath('<args>')
     command! -n=0 -bar NERDTreeFocus call NERDTreeFocus()
     command! -n=0 -bar NERDTreeCWD call NERDTreeCWD()
+endfunction
+
+" Function: s:createTree(name) {{{1
+function s:createTree(name)
+    if g:NERDTreeUseCurrentWindow
+        call g:NERDTreeCreator.CreateWindowTree(a:name)
+    else
+        call g:NERDTreeCreator.CreateTabTree(a:name)
+    endif
+endfunction
+
+" Function: s:toggleTree(name) {{{1
+function s:toggleTree(name)
+    if g:NERDTreeUseCurrentWindow
+        call g:NERDTreeCreator.ToggleWindowTree(a:name)
+    else
+        call g:NERDTreeCreator.ToggleTabTree(a:name)
+    endif
+endfunction
+
+" Function: s:closeTree() {{{1
+function s:closeTree()
+    if g:NERDTreeUseCurrentWindow
+        call g:NERDTree.CloseWindowTree()
+    else
+        call g:NERDTree.Close()
+    endif
 endfunction
 
 " Function: s:SID()   {{{1

--- a/doc/NERDTree.txt
+++ b/doc/NERDTree.txt
@@ -639,6 +639,9 @@ NERD tree. These options should be set in your vimrc.
 |'NERDTreeHijackNetrw'|         Tell the NERD tree whether to replace the netrw
                                 autocommands for exploring local directories.
 
+|'NERDTreeUseCurrentWindow'|    Tells the NERD tree whether to render in side
+                                window or current window.
+
 |'NERDTreeIgnore'|              Tells the NERD tree which files to ignore.
 
 |'NERDTreeRespectWildIgnore'|   Tells the NERD tree to respect |'wildignore'|.
@@ -832,6 +835,14 @@ following respects:
     1. 'o' will open the selected file in the same window as the tree,
        replacing it.
     2. you can have one tree per window - instead of per tab.
+
+------------------------------------------------------------------------------
+                                                  *'NERDTreeUseCurrentWindow'*
+Values: 0 or 1.
+Default: 0.
+
+If set to 1, NERD tree will open in the current window instead of a side window.
+This option affects all NERD tree commands except |:NERDTreeMirror|.
 
 ------------------------------------------------------------------------------
                                                             *'NERDTreeIgnore'*

--- a/lib/nerdtree/nerdtree.vim
+++ b/lib/nerdtree/nerdtree.vim
@@ -71,6 +71,13 @@ function! s:NERDTree.CloseIfQuitOnOpen()
     endif
 endfunction
 
+" FUNCTION: s:NERDTree.CloseWindowTree() {{{1
+function! s:NERDTree.CloseWindowTree()
+    if s:NERDTree.IsWindowTreeOpen()
+        exec "buffer " . b:NERDTree.previousBuf()
+    endif
+endfunction
+
 "FUNCTION: s:NERDTree.CursorToBookmarkTable(){{{1
 "Places the cursor at the top of the bookmarks table
 function! s:NERDTree.CursorToBookmarkTable()
@@ -118,6 +125,17 @@ function! s:NERDTree.ExistsForTab()
     return !empty(getbufvar(bufnr(t:NERDTreeBufName), 'NERDTree'))
 endfunction
 
+" Function: s:NERDTree.ExistsForWindow()   {{{1
+" Returns 1 if a nerd tree root exists in the current window
+function! s:NERDTree.ExistsForWindow()
+    if !exists("w:NERDTreeBufName")
+        return
+    end
+
+    " check b:NERDTree is still there and hasn't been e.g. :bdeleted
+    return !empty(getbufvar(bufnr(w:NERDTreeBufName), 'NERDTree'))
+endfunction
+
 function! s:NERDTree.ForCurrentBuf()
     if s:NERDTree.ExistsForBuf()
         return b:NERDTree
@@ -154,6 +172,12 @@ endfunction
 "FUNCTION: s:NERDTree.IsOpen() {{{1
 function! s:NERDTree.IsOpen()
     return s:NERDTree.GetWinNum() != -1
+endfunction
+
+"FUNCTION: s:NERDTree.IsWindowTreeOpen() {{{1
+function! s:NERDTree.IsWindowTreeOpen()
+    let nerdtree = s:NERDTree.ForCurrentBuf()
+    return !empty(nerdtree) && nerdtree.isWinTree()
 endfunction
 
 "FUNCTION: s:NERDTree.isTabTree() {{{1

--- a/plugin/NERD_tree.vim
+++ b/plugin/NERD_tree.vim
@@ -68,6 +68,7 @@ call s:initVariable("g:NERDTreeShowFiles", 1)
 call s:initVariable("g:NERDTreeShowHidden", 0)
 call s:initVariable("g:NERDTreeShowLineNumbers", 0)
 call s:initVariable("g:NERDTreeSortDirs", 1)
+call s:initVariable("g:NERDTreeUseCurrentWindow", 0)
 
 if !nerdtree#runningWindows() && !nerdtree#runningCygwin()
     call s:initVariable("g:NERDTreeDirArrowExpandable", "▸")
@@ -198,6 +199,12 @@ function! NERDTreeRender()
 endfunction
 
 function! NERDTreeFocus()
+    if g:NERDTreeUseCurrentWindow
+        if !g:NERDTree.IsWindowTreeOpen()
+            call g:NERDTreeCreator.ToggleWindowTree("")
+        endif
+        return
+    endif
     if g:NERDTree.IsOpen()
         call g:NERDTree.CursorToTreeWin()
     else


### PR DESCRIPTION
In a multi-window workflow, it's often desirable to make NERDTree to
work in the current window instead of its side window. See issue #244
for brief discussion.

Currently it's possible to use `:e <dir>` to achieve this for
`:NERDTree` command; but there are no workarounds for other functions
like opening bookmark, toggling nerdtree, finding current file, etc.

This commit adds an option to render NERDTree in current window instead
of side window, and modifies all relevant commands to respect the
option.