### PR TITLE
Bugfix - ensure keymaps dictionary exists before using it

### DIFF
--- a/lib/nerdtree/key_map.vim
+++ b/lib/nerdtree/key_map.vim
@@ -2,19 +2,11 @@
 "============================================================
 let s:KeyMap = {}
 let g:NERDTreeKeyMap = s:KeyMap
-
-"FUNCTION: KeyMap._all() {{{1
-function! s:KeyMap._all()
-    if !exists("s:keyMaps")
-        let s:keyMaps = {}
-    endif
-
-    return s:keyMaps
-endfunction
+let s:keyMaps = {}
 
 "FUNCTION: KeyMap.All() {{{1
 function! s:KeyMap.All()
-    let sortedKeyMaps = values(s:KeyMap._all())
+    let sortedKeyMaps = values(s:keyMaps)
     call sort(sortedKeyMaps, s:KeyMap.Compare, s:KeyMap)
 
     return sortedKeyMaps
@@ -36,12 +28,12 @@ endfunction
 
 "FUNCTION: KeyMap.FindFor(key, scope) {{{1
 function! s:KeyMap.FindFor(key, scope)
-    return get(s:KeyMap._all(), a:key . a:scope, {})
+    return get(s:keyMaps, a:key . a:scope, {})
 endfunction
 
 "FUNCTION: KeyMap.BindAll() {{{1
 function! s:KeyMap.BindAll()
-    for i in values(s:KeyMap._all())
+    for i in values(s:keyMaps)
         call i.bind()
     endfor
 endfunction


### PR DESCRIPTION
I realized I might have introduced a bug in https://github.com/scrooloose/nerdtree/pull/851, I haven't been able to trigger it but I wanted to be safe rather then sorry.

The `KeyMap.Add` and `KeyMaps.Remove` functions can't use `KeyMap._all` to fetch the key map dictionary since they need to modify it, and it appears the dictionary returned by the `KeyMap._all` function is a copy, and modifying the copy doesn't modify the underlying `s:keyMaps` variable. However, using the `s:keyMaps` variable directly is error prone since the variable will be undefined until the very first invocation of `KeyMap._all`.

This PR invokes and discards the result of `KeyMap._all` prior to adding or removing any key maps from `s:keyMaps`directly, just to ensure `s:keyMaps` is defined.