### PR TITLE
Better OSX detection

### DIFF
--- a/nerdtree_plugin/fs_menu.vim
+++ b/nerdtree_plugin/fs_menu.vim
@@ -228,7 +228,7 @@ function! NERDTreeListNode()
         if has("unix")
             let s:uname = system("uname")
             let stat_cmd = 'stat -c "%s" ' 
-            if s:uname == "Darwin\n"
+            if s:uname =~? "Darwin"
                 let stat_cmd = 'stat -f "%z" '
             endif
         endif

--- a/nerdtree_plugin/fs_menu.vim
+++ b/nerdtree_plugin/fs_menu.vim
@@ -225,12 +225,11 @@ endfunction
 function! NERDTreeListNode()
     let treenode = g:NERDTreeFileNode.GetSelected()
     if !empty(treenode)
-        if has("unix")
-            let s:uname = system("uname")
-            let stat_cmd = 'stat -c "%s" ' 
-            if s:uname =~? "Darwin"
-                let stat_cmd = 'stat -f "%z" '
-            endif
+        let s:uname = system("uname")
+        let stat_cmd = 'stat -c "%s" ' 
+        
+        if s:uname =~? "Darwin"                
+            let stat_cmd = 'stat -f "%z" '
         endif
 
         let cmd = 'size=$(' . stat_cmd . shellescape(treenode.path.str()) . ') && ' .

--- a/nerdtree_plugin/fs_menu.vim
+++ b/nerdtree_plugin/fs_menu.vim
@@ -225,10 +225,12 @@ endfunction
 function! NERDTreeListNode()
     let treenode = g:NERDTreeFileNode.GetSelected()
     if !empty(treenode)
-        if has("osx")
-            let stat_cmd = 'stat -f "%z" '
-        else
-            let stat_cmd = 'stat -c "%s" '
+        if has("unix")
+            let s:uname = system("uname")
+            let stat_cmd = 'stat -c "%s" ' 
+            if s:uname == "Darwin\n"
+                let stat_cmd = 'stat -f "%z" '
+            endif
         endif
 
         let cmd = 'size=$(' . stat_cmd . shellescape(treenode.path.str()) . ') && ' .


### PR DESCRIPTION
Neovim does not support an *osx* feature to test for. This PR implements a more generic test for the OSX operating system in order to ensure the correct `stat` command is used.