### PR TITLE
Fix issues with sorting of nodes

### DIFF
--- a/autoload/nerdtree.vim
+++ b/autoload/nerdtree.vim
@@ -61,7 +61,6 @@ endfunction
 function! nerdtree#compareNodesBySortKey(n1, n2)
     let sortKey1 = a:n1.path.getSortKey()
     let sortKey2 = a:n2.path.getSortKey()
-
     let i = 0
     while i < min([len(sortKey1), len(sortKey2)])
         " Compare chunks upto common length.
@@ -73,9 +72,9 @@ function! nerdtree#compareNodesBySortKey(n1, n2)
             elseif sortKey1[i] ># sortKey2[i]
                 return 1
             endif
-        elseif sortKey1[i] == type(0)
+        elseif type(sortKey1[i]) == v:t_number
             return -1
-        elseif sortKey2[i] == type(0)
+        elseif type(sortKey2[i]) == v:t_number
             return 1
         endif
         let i = i + 1

--- a/lib/nerdtree/path.vim
+++ b/lib/nerdtree/path.vim
@@ -392,17 +392,19 @@ endfunction
 " FUNCTION: Path.getSortKey() {{{1
 " returns a key used in compare function for sorting
 function! s:Path.getSortKey()
-    let path = self.getLastPathComponent(1)
-    if !g:NERDTreeSortHiddenFirst
-        let path = substitute(path, '^[._]', '', '')
-    endif
-    if !g:NERDTreeCaseSensitiveSort
-        let path = tolower(path)
-    endif
-    if !g:NERDTreeNaturalSort
-        let self._sortKey = [self.getSortOrderIndex(), path]
-    else
-        let self._sortKey = [self.getSortOrderIndex()] + self._splitChunks(path)
+    if !exists("self._sortKey") || g:NERDTreeSortOrder !=# g:NERDTreeOldSortOrder
+        let path = self.getLastPathComponent(1)
+        if !g:NERDTreeSortHiddenFirst
+            let path = substitute(path, '^[._]', '', '')
+        endif
+        if !g:NERDTreeCaseSensitiveSort
+            let path = tolower(path)
+        endif
+        if !g:NERDTreeNaturalSort
+            let self._sortKey = [self.getSortOrderIndex(), path]
+        else
+            let self._sortKey = [self.getSortOrderIndex()] + self._splitChunks(path)
+        endif
     endif
 
     return self._sortKey

--- a/lib/nerdtree/path.vim
+++ b/lib/nerdtree/path.vim
@@ -392,18 +392,18 @@ endfunction
 " FUNCTION: Path.getSortKey() {{{1
 " returns a key used in compare function for sorting
 function! s:Path.getSortKey()
-        let path = self.getLastPathComponent(1)
-        if !g:NERDTreeSortHiddenFirst
-            let path = substitute(path, '^[._]', '', '')
-        endif
-        if !g:NERDTreeCaseSensitiveSort
-            let path = tolower(path)
-        endif
-        if !g:NERDTreeNaturalSort
-            let self._sortKey = [self.getSortOrderIndex(), path]
-        else
-            let self._sortKey = [self.getSortOrderIndex()] + self._splitChunks(path)
-        endif
+    let path = self.getLastPathComponent(1)
+    if !g:NERDTreeSortHiddenFirst
+        let path = substitute(path, '^[._]', '', '')
+    endif
+    if !g:NERDTreeCaseSensitiveSort
+        let path = tolower(path)
+    endif
+    if !g:NERDTreeNaturalSort
+        let self._sortKey = [self.getSortOrderIndex(), path]
+    else
+        let self._sortKey = [self.getSortOrderIndex()] + self._splitChunks(path)
+    endif
 
     return self._sortKey
 endfunction

--- a/lib/nerdtree/path.vim
+++ b/lib/nerdtree/path.vim
@@ -7,10 +7,6 @@
 " ============================================================================
 
 
-" This constant is used throughout this script for sorting purposes.
-let s:NERDTreeSortStarIndex = index(g:NERDTreeSortOrder, '*')
-lockvar s:NERDTreeSortStarIndex
-
 let s:Path = {}
 let g:NERDTreePath = s:Path
 
@@ -374,7 +370,8 @@ function! s:Path.getSortOrderIndex()
         endif
         let i = i + 1
     endwhile
-    return s:NERDTreeSortStarIndex
+
+    return index(g:NERDTreeSortOrder, '*')
 endfunction
 
 " FUNCTION: Path._splitChunks(path) {{{1
@@ -395,7 +392,6 @@ endfunction
 " FUNCTION: Path.getSortKey() {{{1
 " returns a key used in compare function for sorting
 function! s:Path.getSortKey()
-    if !exists("self._sortKey")
         let path = self.getLastPathComponent(1)
         if !g:NERDTreeSortHiddenFirst
             let path = substitute(path, '^[._]', '', '')
@@ -408,7 +404,6 @@ function! s:Path.getSortKey()
         else
             let self._sortKey = [self.getSortOrderIndex()] + self._splitChunks(path)
         endif
-    endif
 
     return self._sortKey
 endfunction

--- a/lib/nerdtree/tree_dir_node.vim
+++ b/lib/nerdtree/tree_dir_node.vim
@@ -607,7 +607,9 @@ endfunction
 " FUNCTION: TreeDirNode.sortChildren() {{{1
 " Sort "self.children" by alphabetical order and directory priority.
 function! s:TreeDirNode.sortChildren()
-    call AddDefaultGroupToSortOrder()
+    if count(g:NERDTreeSortOrder, '*') < 1
+        call add(g:NERDTreeSortOrder, '*')
+    endif
     let CompareFunc = function("nerdtree#compareNodesBySortKey")
     call sort(self.children, CompareFunc)
 endfunction

--- a/lib/nerdtree/tree_dir_node.vim
+++ b/lib/nerdtree/tree_dir_node.vim
@@ -612,6 +612,7 @@ function! s:TreeDirNode.sortChildren()
     endif
     let CompareFunc = function("nerdtree#compareNodesBySortKey")
     call sort(self.children, CompareFunc)
+    let g:NERDTreeOldSortOrder = g:NERDTreeSortOrder
 endfunction
 
 " FUNCTION: TreeDirNode.toggleOpen([options]) {{{1

--- a/lib/nerdtree/tree_dir_node.vim
+++ b/lib/nerdtree/tree_dir_node.vim
@@ -607,6 +607,7 @@ endfunction
 " FUNCTION: TreeDirNode.sortChildren() {{{1
 " Sort "self.children" by alphabetical order and directory priority.
 function! s:TreeDirNode.sortChildren()
+    call AddDefaultGroupToSortOrder()
     let CompareFunc = function("nerdtree#compareNodesBySortKey")
     call sort(self.children, CompareFunc)
 endfunction

--- a/plugin/NERD_tree.vim
+++ b/plugin/NERD_tree.vim
@@ -24,15 +24,6 @@ let loaded_nerd_tree = 1
 let s:old_cpo = &cpo
 set cpo&vim
 
-"Function: AddDefaultGroupToSortOrder() function {{{2
-"This function adds the default grouping '*' to the sort sequence if it's not
-"already in the list.
-function! AddDefaultGroupToSortOrder()
-    if count(g:NERDTreeSortOrder, '*') < 1
-        call add(g:NERDTreeSortOrder, '*')
-    endif
-endfunction
-
 "Function: s:initVariable() function {{{2
 "This function is used to initialise a given variable to a given value. The
 "variable is only initialised if it does not exist prior
@@ -90,8 +81,6 @@ call s:initVariable("g:NERDTreeCascadeSingleChildDir", 1)
 
 if !exists("g:NERDTreeSortOrder")
     let g:NERDTreeSortOrder = ['\/$', '*', '\.swp$',  '\.bak$', '\~$']
-else
-    call AddDefaultGroupToSortOrder()
 endif
 
 call s:initVariable("g:NERDTreeGlyphReadOnly", "RO")

--- a/plugin/NERD_tree.vim
+++ b/plugin/NERD_tree.vim
@@ -24,6 +24,15 @@ let loaded_nerd_tree = 1
 let s:old_cpo = &cpo
 set cpo&vim
 
+"Function: AddDefaultGroupToSortOrder() function {{{2
+"This function adds the default grouping '*' to the sort sequence if it's not
+"already in the list.
+function! AddDefaultGroupToSortOrder()
+    if count(g:NERDTreeSortOrder, '*') < 1
+        call add(g:NERDTreeSortOrder, '*')
+    endif
+endfunction
+
 "Function: s:initVariable() function {{{2
 "This function is used to initialise a given variable to a given value. The
 "variable is only initialised if it does not exist prior
@@ -82,10 +91,7 @@ call s:initVariable("g:NERDTreeCascadeSingleChildDir", 1)
 if !exists("g:NERDTreeSortOrder")
     let g:NERDTreeSortOrder = ['\/$', '*', '\.swp$',  '\.bak$', '\~$']
 else
-    "if there isnt a * in the sort sequence then add one
-    if count(g:NERDTreeSortOrder, '*') < 1
-        call add(g:NERDTreeSortOrder, '*')
-    endif
+    call AddDefaultGroupToSortOrder()
 endif
 
 call s:initVariable("g:NERDTreeGlyphReadOnly", "RO")

--- a/plugin/NERD_tree.vim
+++ b/plugin/NERD_tree.vim
@@ -82,6 +82,7 @@ call s:initVariable("g:NERDTreeCascadeSingleChildDir", 1)
 if !exists("g:NERDTreeSortOrder")
     let g:NERDTreeSortOrder = ['\/$', '*', '\.swp$',  '\.bak$', '\~$']
 endif
+let g:NERDTreeOldSortOrder = []
 
 call s:initVariable("g:NERDTreeGlyphReadOnly", "RO")
 


### PR DESCRIPTION
This  PR fixes two issues: 
1. #842  (See `autoload/nerdtree.vim`)
> The sort algorithm was incorrectly comparing the value in the sort key to the type of the integer 0. Instead it should have been checking the type of the sort key's value to see it is numeric.

1. #277  (See `lib/nerdtree/path.vim`, `lib/nerdtree/tree_dir_node.vim`, and `plugin/NERD_tree.vim`)
> This issue reported that NERDTree was respecting only the first item in the sort order. It was probably more accurate to say that **changing the NERDTreeSortOrder in the current session, then refreshing NERDTree** didn't produce correctly sorted nodes. When doing this, NERDTree was using the cached value for the nodes' sortKey, which could be different than it needed to be for the new SortOrder. To fix this, I changed the code to always calculate the sortKey, instead of relying on a cached value. This adds some processing time, which may or may not be deemed acceptable.