### PR TITLE
Reword renamed-buffer prompt to be more clear

### DIFF
--- a/nerdtree_plugin/fs_menu.vim
+++ b/nerdtree_plugin/fs_menu.vim
@@ -164,7 +164,7 @@ function! NERDTreeMoveNode()
         "if the node is open in a buffer, ask the user if they want to
         "close that buffer
         if bufnum != -1
-            let prompt = "\nNode renamed.\n\nThe old file is open in buffer ". bufnum . (bufwinnr(bufnum) ==# -1 ? " (hidden)" : "") .". Replace this buffer with a new file? (yN)"
+            let prompt = "\nNode renamed.\n\nThe old file is open in buffer ". bufnum . (bufwinnr(bufnum) ==# -1 ? " (hidden)" : "") .". Replace this buffer with the new file? (yN)"
             call s:promptToRenameBuffer(bufnum,  prompt, newNodePath)
         endif
 


### PR DESCRIPTION
When renaming a file that is currently open in a buffer, NerdTree helpfully asks us:
```
Node renamed. The old file is open in buffer <buf>. Replace this buffer with *a* new file? (yN)
```
(emphasis mine)

This is slightly confusing as replacing the buffer with **a** new file isn't what is meant, instead we can be more clear just by saying 'the new file', the one we just renamed to. 
```
Node renamed. The old file is open in buffer <buf>. Replace this buffer with the new file? (yN)
```