### PR TITLE
Support unusual characters in file and directory names

### DIFF
--- a/lib/nerdtree/path.vim
+++ b/lib/nerdtree/path.vim
@@ -42,7 +42,7 @@ function! s:Path.cacheDisplayString() abort
     let self.cachedDisplayString = g:NERDTreeNodeDelimiter . self.getLastPathComponent(1)
 
     if self.isExecutable
-        let self.cachedDisplayString .= (self.cachedDisplayString =~ g:NERDTreeNodeDelimiter.'$' ? '' : g:NERDTreeNodeDelimiter) . '*'
+        let self.cachedDisplayString = self.addDelimiter(self.cachedDisplayString) . '*'
     endif
 
     let self._bookmarkNames = []
@@ -52,15 +52,24 @@ function! s:Path.cacheDisplayString() abort
         endif
     endfor
     if !empty(self._bookmarkNames) && g:NERDTreeMarkBookmarks == 1
-        let self.cachedDisplayString .= (self.cachedDisplayString =~ g:NERDTreeNodeDelimiter.'$' ? '' : g:NERDTreeNodeDelimiter) . ' {' . join(self._bookmarkNames) . '}'
+        let self.cachedDisplayString = self.addDelimiter(self.cachedDisplayString) . ' {' . join(self._bookmarkNames) . '}'
     endif
 
     if self.isSymLink
-        let self.cachedDisplayString .= (self.cachedDisplayString =~ g:NERDTreeNodeDelimiter.'$' ? '' : g:NERDTreeNodeDelimiter) . ' -> ' . self.symLinkDest
+        let self.cachedDisplayString = self.addDelimiter(self.cachedDisplayString) . ' -> ' . self.symLinkDest
     endif
 
     if self.isReadOnly
-        let self.cachedDisplayString .= (self.cachedDisplayString =~ g:NERDTreeNodeDelimiter.'$' ? '' : g:NERDTreeNodeDelimiter) . ' ['.g:NERDTreeGlyphReadOnly.']'
+        let self.cachedDisplayString = self.addDelimiter(self.cachedDisplayString) . ' ['.g:NERDTreeGlyphReadOnly.']'
+    endif
+endfunction
+
+" FUNCTION: Path.addDelimiter() {{{1
+function! s:Path.addDelimiter(line)
+    if a:line =~# '\(.*' . g:NERDTreeNodeDelimiter . '\)\{2}'
+        return a:line
+    else
+        return a:line . g:NERDTreeNodeDelimiter
     endif
 endfunction
 

--- a/lib/nerdtree/path.vim
+++ b/lib/nerdtree/path.vim
@@ -42,7 +42,7 @@ function! s:Path.cacheDisplayString() abort
     let self.cachedDisplayString = g:NERDTreeNodeDelimiter . self.getLastPathComponent(1) . g:NERDTreeNodeDelimiter
 
     if self.isExecutable
-        let self.cachedDisplayString = self.cachedDisplayString . '*'
+        let self.cachedDisplayString .= '*'
     endif
 
     let self._bookmarkNames = []

--- a/lib/nerdtree/path.vim
+++ b/lib/nerdtree/path.vim
@@ -43,10 +43,10 @@ endfunction
 
 " FUNCTION: Path.cacheDisplayString() {{{1
 function! s:Path.cacheDisplayString() abort
-    let self.cachedDisplayString = self.getLastPathComponent(1)
+    let self.cachedDisplayString = g:NERDTreeNodeDelimiter . self.getLastPathComponent(1) . g:NERDTreeNodeDelimiter
 
     if self.isExecutable
-        let self.cachedDisplayString = self.cachedDisplayString . g:NERDTreeNodeDelimiter.'*'
+        let self.cachedDisplayString = self.cachedDisplayString . '*'
     endif
 
     let self._bookmarkNames = []
@@ -56,15 +56,15 @@ function! s:Path.cacheDisplayString() abort
         endif
     endfor
     if !empty(self._bookmarkNames) && g:NERDTreeMarkBookmarks == 1
-        let self.cachedDisplayString .= g:NERDTreeNodeDelimiter.'{' . join(self._bookmarkNames) . '}'
+        let self.cachedDisplayString .= ' {' . join(self._bookmarkNames) . '}'
     endif
 
     if self.isSymLink
-        let self.cachedDisplayString .=  g:NERDTreeNodeDelimiter.'-> ' . self.symLinkDest
+        let self.cachedDisplayString .=  ' -> ' . self.symLinkDest
     endif
 
     if self.isReadOnly
-        let self.cachedDisplayString .=  g:NERDTreeNodeDelimiter.'['.g:NERDTreeGlyphReadOnly.']'
+        let self.cachedDisplayString .=  ' ['.g:NERDTreeGlyphReadOnly.']'
     endif
 endfunction
 

--- a/lib/nerdtree/path.vim
+++ b/lib/nerdtree/path.vim
@@ -39,10 +39,10 @@ endfunction
 
 " FUNCTION: Path.cacheDisplayString() {{{1
 function! s:Path.cacheDisplayString() abort
-    let self.cachedDisplayString = g:NERDTreeNodeDelimiter . self.getLastPathComponent(1) . g:NERDTreeNodeDelimiter
+    let self.cachedDisplayString = g:NERDTreeNodeDelimiter . self.getLastPathComponent(1)
 
     if self.isExecutable
-        let self.cachedDisplayString .= '*'
+        let self.cachedDisplayString .= (self.cachedDisplayString =~ g:NERDTreeNodeDelimiter.'$' ? '' : g:NERDTreeNodeDelimiter) . '*'
     endif
 
     let self._bookmarkNames = []
@@ -52,15 +52,15 @@ function! s:Path.cacheDisplayString() abort
         endif
     endfor
     if !empty(self._bookmarkNames) && g:NERDTreeMarkBookmarks == 1
-        let self.cachedDisplayString .= ' {' . join(self._bookmarkNames) . '}'
+        let self.cachedDisplayString .= (self.cachedDisplayString =~ g:NERDTreeNodeDelimiter.'$' ? '' : g:NERDTreeNodeDelimiter) . ' {' . join(self._bookmarkNames) . '}'
     endif
 
     if self.isSymLink
-        let self.cachedDisplayString .=  ' -> ' . self.symLinkDest
+        let self.cachedDisplayString .= (self.cachedDisplayString =~ g:NERDTreeNodeDelimiter.'$' ? '' : g:NERDTreeNodeDelimiter) . ' -> ' . self.symLinkDest
     endif
 
     if self.isReadOnly
-        let self.cachedDisplayString .=  ' ['.g:NERDTreeGlyphReadOnly.']'
+        let self.cachedDisplayString .= (self.cachedDisplayString =~ g:NERDTreeNodeDelimiter.'$' ? '' : g:NERDTreeNodeDelimiter) . ' ['.g:NERDTreeGlyphReadOnly.']'
     endif
 endfunction
 

--- a/lib/nerdtree/path.vim
+++ b/lib/nerdtree/path.vim
@@ -46,7 +46,7 @@ function! s:Path.cacheDisplayString() abort
     let self.cachedDisplayString = self.getLastPathComponent(1)
 
     if self.isExecutable
-        let self.cachedDisplayString = self.cachedDisplayString . '*'
+        let self.cachedDisplayString = self.cachedDisplayString . g:NERDTreeNodeDelimiter.'*'
     endif
 
     let self._bookmarkNames = []
@@ -56,15 +56,15 @@ function! s:Path.cacheDisplayString() abort
         endif
     endfor
     if !empty(self._bookmarkNames) && g:NERDTreeMarkBookmarks == 1
-        let self.cachedDisplayString .= ' {' . join(self._bookmarkNames) . '}'
+        let self.cachedDisplayString .= g:NERDTreeNodeDelimiter.'{' . join(self._bookmarkNames) . '}'
     endif
 
     if self.isSymLink
-        let self.cachedDisplayString .=  ' -> ' . self.symLinkDest
+        let self.cachedDisplayString .=  g:NERDTreeNodeDelimiter.'-> ' . self.symLinkDest
     endif
 
     if self.isReadOnly
-        let self.cachedDisplayString .=  ' ['.g:NERDTreeGlyphReadOnly.']'
+        let self.cachedDisplayString .=  g:NERDTreeNodeDelimiter.'['.g:NERDTreeGlyphReadOnly.']'
     endif
 endfunction
 

--- a/lib/nerdtree/tree_dir_node.vim
+++ b/lib/nerdtree/tree_dir_node.vim
@@ -111,7 +111,7 @@ function! s:TreeDirNode.displayString()
 
     let l:flags = l:cascade[-1].path.flagSet.renderToString()
 
-    let l:result = l:symbol . l:flags . g:NERDTreeNodeDelimiter . l:label
+    let l:result = l:symbol . ' ' . l:flags . l:label
     return l:result
 endfunction
 

--- a/lib/nerdtree/tree_dir_node.vim
+++ b/lib/nerdtree/tree_dir_node.vim
@@ -99,7 +99,8 @@ function! s:TreeDirNode.displayString()
     let l:label = ''
     let l:cascade = self.getCascade()
     for l:dirNode in l:cascade
-        let l:label .= l:dirNode.path.displayString()
+        let l:next = l:dirNode.path.displayString()
+        let l:label .= l:label == '' ? l:next : strcharpart(l:next,1)
     endfor
 
     " Select the appropriate open/closed status indicator symbol.

--- a/lib/nerdtree/tree_dir_node.vim
+++ b/lib/nerdtree/tree_dir_node.vim
@@ -111,7 +111,7 @@ function! s:TreeDirNode.displayString()
 
     let l:flags = l:cascade[-1].path.flagSet.renderToString()
 
-    let l:result = l:symbol . ' ' . l:flags . g:NERDTreeNodeDelimiter . l:label
+    let l:result = l:symbol . l:flags . g:NERDTreeNodeDelimiter . l:label
     return l:result
 endfunction
 

--- a/lib/nerdtree/tree_dir_node.vim
+++ b/lib/nerdtree/tree_dir_node.vim
@@ -111,7 +111,7 @@ function! s:TreeDirNode.displayString()
 
     let l:flags = l:cascade[-1].path.flagSet.renderToString()
 
-    let l:result = l:symbol . ' ' . l:flags . l:label
+    let l:result = l:symbol . ' ' . l:flags . g:NERDTreeNodeDelimiter . l:label
     return l:result
 endfunction
 

--- a/lib/nerdtree/tree_dir_node.vim
+++ b/lib/nerdtree/tree_dir_node.vim
@@ -278,9 +278,11 @@ function! s:TreeDirNode._glob(pattern, all)
         for l:file in l:globList
             let l:tail = fnamemodify(l:file, ':t')
 
-            " Double the modifier if only a separator was stripped.
+            " If l:file has a trailing slash, then its :tail will be ''. Use
+            " :h to drop the slash and the empty string after it; then use :t
+            " to get the directory name.
             if l:tail == ''
-                let l:tail = fnamemodify(l:file, ':t:t')
+                let l:tail = fnamemodify(l:file, ':h:t')
             endif
 
             if l:tail == '.' || l:tail == '..'

--- a/lib/nerdtree/tree_file_node.vim
+++ b/lib/nerdtree/tree_file_node.vim
@@ -86,7 +86,7 @@ endfunction
 " Return:
 " a string that can be used in the view to represent this node
 function! s:TreeFileNode.displayString()
-    return self.path.flagSet.renderToString() . self.path.displayString()
+    return self.path.flagSet.renderToString() . g:NERDTreeNodeDelimiter . self.path.displayString()
 endfunction
 
 " FUNCTION: TreeFileNode.equals(treenode) {{{1

--- a/lib/nerdtree/tree_file_node.vim
+++ b/lib/nerdtree/tree_file_node.vim
@@ -86,7 +86,7 @@ endfunction
 " Return:
 " a string that can be used in the view to represent this node
 function! s:TreeFileNode.displayString()
-    return self.path.flagSet.renderToString() . g:NERDTreeNodeDelimiter . self.path.displayString()
+    return self.path.flagSet.renderToString() . self.path.displayString()
 endfunction
 
 " FUNCTION: TreeFileNode.equals(treenode) {{{1

--- a/lib/nerdtree/tree_file_node.vim
+++ b/lib/nerdtree/tree_file_node.vim
@@ -270,7 +270,7 @@ endfunction
 
 " FUNCTION: TreeFileNode.openInNewTab(options) {{{1
 function! s:TreeFileNode.openInNewTab(options)
-    echomsg 'TreeFileNode.openInNewTab is deprecated'
+    call nerdtree#deprecated('TreeFileNode.openinNewTab', 'is deprecated, use .open() instead.')
     call self.open(extend({'where': 't'}, a:options))
 endfunction
 

--- a/lib/nerdtree/ui.vim
+++ b/lib/nerdtree/ui.vim
@@ -367,7 +367,8 @@ endfunction
 " Args:
 " line: the subject line
 function! s:UI._stripMarkup(line)
-    return substitute(a:line, '^.\{-}' . g:NERDTreeNodeDelimiter . '\(.*\)' . g:NERDTreeNodeDelimiter . '.*', '\1', '')
+    let line = substitute(a:line, '^.\{-}' . g:NERDTreeNodeDelimiter . '\(.*\)' . g:NERDTreeNodeDelimiter . '.*', '\1', '')
+    return substitute(line, g:NERDTreeNodeDelimiter, '', 'g')
 endfunction
 
 " FUNCTION: s:UI.render() {{{1

--- a/lib/nerdtree/ui.vim
+++ b/lib/nerdtree/ui.vim
@@ -368,8 +368,9 @@ endfunction
 " Args:
 " line: the subject line
 function! s:UI._stripMarkup(line)
-    let line = substitute(a:line, '^.\{-}' . g:NERDTreeNodeDelimiter . '\(.*\)' . g:NERDTreeNodeDelimiter . '.*', '\1', '')
-    return substitute(line, g:NERDTreeNodeDelimiter, '', 'g')
+    let l:line = substitute(a:line, g:NERDTreeNodeDelimiter . '\{2}', '', '')
+    let l:line = substitute(l:line, '^.\{-}' . g:NERDTreeNodeDelimiter, '', '')
+    return substitute(l:line, g:NERDTreeNodeDelimiter.'.*$', '', '')
 endfunction
 
 " FUNCTION: s:UI.render() {{{1

--- a/lib/nerdtree/ui.vim
+++ b/lib/nerdtree/ui.vim
@@ -299,7 +299,7 @@ endfunction
 
 " FUNCTION: s:UI.MarkupReg() {{{1
 function! s:UI.MarkupReg()
-    return '^ *['.g:NERDTreeDirArrowExpandable.g:NERDTreeDirArrowCollapsible.' ] '
+    return '^ *['.g:NERDTreeDirArrowExpandable.g:NERDTreeDirArrowCollapsible.']\? '
 endfunction
 
 " FUNCTION: s:UI._renderBookmarks {{{1

--- a/lib/nerdtree/ui.vim
+++ b/lib/nerdtree/ui.vim
@@ -275,7 +275,7 @@ endfunction
 " FUNCTION: s:UI._indentLevelFor(line) {{{1
 function! s:UI._indentLevelFor(line)
     " have to do this work around because match() returns bytes, not chars
-    let numLeadBytes = match(a:line, '\M\[^ '.g:NERDTreeDirArrowExpandable.g:NERDTreeDirArrowCollapsible.g:NERDTreeNodeDelimiter.']')
+    let numLeadBytes = match(a:line, '\M\[^ '.g:NERDTreeDirArrowExpandable.g:NERDTreeDirArrowCollapsible.']')
     " The next line is a backward-compatible workaround for strchars(a:line(0:numLeadBytes-1]). strchars() is in 7.3+
     let leadChars = len(split(a:line[0:numLeadBytes-1], '\zs'))
 
@@ -299,9 +299,7 @@ endfunction
 
 " FUNCTION: s:UI.MarkupReg() {{{1
 function! s:UI.MarkupReg()
-    return '^\(['.g:NERDTreeDirArrowExpandable.g:NERDTreeDirArrowCollapsible.']'.g:NERDTreeNodeDelimiter.
-         \ '\| \+['.g:NERDTreeDirArrowExpandable.g:NERDTreeDirArrowCollapsible.']'.g:NERDTreeNodeDelimiter.
-         \ '\| \+'.g:NERDTreeNodeDelimiter.'\?\)'
+    return '^ *['.g:NERDTreeDirArrowExpandable.g:NERDTreeDirArrowCollapsible.' ] '
 endfunction
 
 " FUNCTION: s:UI._renderBookmarks {{{1
@@ -364,31 +362,12 @@ function! s:UI.setShowHidden(val)
 endfunction
 
 " FUNCTION: s:UI._stripMarkup(line){{{1
-" returns the given line with all the tree parts stripped off
+" find the filename in the given line, and return it.
 "
 " Args:
 " line: the subject line
 function! s:UI._stripMarkup(line)
-    let line = a:line
-    " remove the tree parts and the leading space
-    let line = substitute (line, g:NERDTreeUI.MarkupReg(),"","")
-
-    " strip off any read only flag
-    let line = substitute (line, g:NERDTreeNodeDelimiter.'\['.g:NERDTreeGlyphReadOnly.'\]', "","")
-
-    " strip off any bookmark flags
-    let line = substitute (line, g:NERDTreeNodeDelimiter.'{[^}]*}', "","")
-
-    " strip off any executable flags
-    let line = substitute (line, '*\ze\('.g:NERDTreeNodeDelimiter.'$\| \)', "","")
-
-    " strip off any generic flags
-    let line = substitute (line, '\[[^]]*\]'.g:NERDTreeNodeDelimiter, "","")
-
-    " strip off link to target file
-    let line = substitute (line,g:NERDTreeNodeDelimiter.'-> .*',"","")
-
-    return line
+    return substitute(a:line, '^.\{-}' . g:NERDTreeNodeDelimiter . '\(.*\)' . g:NERDTreeNodeDelimiter . '.*', '\1', '')
 endfunction
 
 " FUNCTION: s:UI.render() {{{1

--- a/lib/nerdtree/ui.vim
+++ b/lib/nerdtree/ui.vim
@@ -368,8 +368,7 @@ endfunction
 " Args:
 " line: the subject line
 function! s:UI._stripMarkup(line)
-    let l:line = substitute(a:line, g:NERDTreeNodeDelimiter . '\{2}', '', '')
-    let l:line = substitute(l:line, '^.\{-}' . g:NERDTreeNodeDelimiter, '', '')
+    let l:line = substitute(a:line, '^.\{-}' . g:NERDTreeNodeDelimiter, '', '')
     return substitute(l:line, g:NERDTreeNodeDelimiter.'.*$', '', '')
 endfunction
 

--- a/lib/nerdtree/ui.vim
+++ b/lib/nerdtree/ui.vim
@@ -385,10 +385,8 @@ function! s:UI._stripMarkup(line)
     " strip off any generic flags
     let line = substitute (line, '\[[^]]*\]'.g:NERDTreeNodeDelimiter, "","")
 
-    let line = substitute (line,g:NERDTreeNodeDelimiter.'-> .*',"","") " remove link to
-
-    " strip off any leading delimiter
-    let line = substitute (line, '^'.g:NERDTreeNodeDelimiter, "","")
+    " strip off link to target file
+    let line = substitute (line,g:NERDTreeNodeDelimiter.'-> .*',"","")
 
     return line
 endfunction

--- a/lib/nerdtree/ui.vim
+++ b/lib/nerdtree/ui.vim
@@ -372,18 +372,21 @@ function! s:UI._stripMarkup(line)
     let line = substitute (line, g:NERDTreeUI.MarkupReg(),"","")
 
     " strip off any read only flag
-    let line = substitute (line, ' \['.g:NERDTreeGlyphReadOnly.'\]', "","")
+    let line = substitute (line, g:NERDTreeNodeDelimiter.'\['.g:NERDTreeGlyphReadOnly.'\]', "","")
 
     " strip off any bookmark flags
-    let line = substitute (line, ' {[^}]*}', "","")
+    let line = substitute (line, g:NERDTreeNodeDelimiter.'{[^}]*}', "","")
 
     " strip off any executable flags
-    let line = substitute (line, '*\ze\($\| \)', "","")
+    let line = substitute (line, '*\ze\('.g:NERDTreeNodeDelimiter.'$\| \)', "","")
 
     " strip off any generic flags
-    let line = substitute (line, '\[[^]]*\]', "","")
+    let line = substitute (line, '\[[^]]*\]'.g:NERDTreeNodeDelimiter, "","")
 
-    let line = substitute (line,' -> .*',"","") " remove link to
+    let line = substitute (line,g:NERDTreeNodeDelimiter.'-> .*',"","") " remove link to
+
+    " strip off any leading delimiter
+    let line = substitute (line, '^'.g:NERDTreeNodeDelimiter, "","")
 
     return line
 endfunction

--- a/lib/nerdtree/ui.vim
+++ b/lib/nerdtree/ui.vim
@@ -275,7 +275,7 @@ endfunction
 " FUNCTION: s:UI._indentLevelFor(line) {{{1
 function! s:UI._indentLevelFor(line)
     " have to do this work around because match() returns bytes, not chars
-    let numLeadBytes = match(a:line, '\M\[^ '.g:NERDTreeDirArrowExpandable.g:NERDTreeDirArrowCollapsible.']')
+    let numLeadBytes = match(a:line, '\M\[^ '.g:NERDTreeDirArrowExpandable.g:NERDTreeDirArrowCollapsible.g:NERDTreeNodeDelimiter.']')
     " The next line is a backward-compatible workaround for strchars(a:line(0:numLeadBytes-1]). strchars() is in 7.3+
     let leadChars = len(split(a:line[0:numLeadBytes-1], '\zs'))
 
@@ -299,7 +299,9 @@ endfunction
 
 " FUNCTION: s:UI.MarkupReg() {{{1
 function! s:UI.MarkupReg()
-    return '^\(['.g:NERDTreeDirArrowExpandable.g:NERDTreeDirArrowCollapsible.'] \| \+['.g:NERDTreeDirArrowExpandable.g:NERDTreeDirArrowCollapsible.'] \| \+\)'
+    return '^\(['.g:NERDTreeDirArrowExpandable.g:NERDTreeDirArrowCollapsible.']'.g:NERDTreeNodeDelimiter.
+         \ '\| \+['.g:NERDTreeDirArrowExpandable.g:NERDTreeDirArrowCollapsible.']'.g:NERDTreeNodeDelimiter.
+         \ '\| \+'.g:NERDTreeNodeDelimiter.'\?\)'
 endfunction
 
 " FUNCTION: s:UI._renderBookmarks {{{1

--- a/plugin/NERD_tree.vim
+++ b/plugin/NERD_tree.vim
@@ -90,6 +90,9 @@ endif
 
 call s:initVariable("g:NERDTreeGlyphReadOnly", "RO")
 
+" ASCII 160: non-breaking space used to delimit items in the tree's nodes.
+call s:initVariable("g:NERDTreeNodeDelimiter", "\u00a0") 
+
 if !exists('g:NERDTreeStatusline')
 
     "the exists() crap here is a hack to stop vim spazzing out when

--- a/plugin/NERD_tree.vim
+++ b/plugin/NERD_tree.vim
@@ -91,7 +91,7 @@ endif
 call s:initVariable("g:NERDTreeGlyphReadOnly", "RO")
 
 " ASCII 160: non-breaking space used to delimit items in the tree's nodes.
-call s:initVariable("g:NERDTreeNodeDelimiter", "\u00a0") 
+call s:initVariable("g:NERDTreeNodeDelimiter", "\u00a0")
 
 if !exists('g:NERDTreeStatusline')
 

--- a/syntax/nerdtree.vim
+++ b/syntax/nerdtree.vim
@@ -38,7 +38,7 @@ syn match NERDTreeFlags #\[.\]# containedin=NERDTreeDir
 
 "highlighing to conceal the delimiter around the file/dir name
 if has("conceal")
-    exec 'syn match NERDTreeNodeDelimiters #' . g:NERDTreeNodeDelimiter . '# conceal containedin=NERDTreeFile,NERDTreeDir'
+    exec 'syn match NERDTreeNodeDelimiters #' . g:NERDTreeNodeDelimiter . '# conceal containedin=NERDTreeFile,NERDTreeLinkFile,NERDTreeRO,NERDTreeDir'
     setlocal conceallevel=2 concealcursor=nvic
 endif
 

--- a/syntax/nerdtree.vim
+++ b/syntax/nerdtree.vim
@@ -40,6 +40,9 @@ syn match NERDTreeFlags #\[.\]# containedin=NERDTreeDir
 if has("conceal")
     exec 'syn match NERDTreeNodeDelimiters #' . g:NERDTreeNodeDelimiter . '# conceal containedin=NERDTreeFile,NERDTreeLinkFile,NERDTreeRO,NERDTreeDir'
     setlocal conceallevel=2 concealcursor=nvic
+else
+    exec 'syn match NERDTreeNodeDelimiters #' . g:NERDTreeNodeDelimiter . '# containedin=NERDTreeFile,NERDTreeLinkFile,NERDTreeRO,NERDTreeDir'
+    hi! link NERDTreeNodeDelimiters Ignore
 endif
 
 syn match NERDTreeCWD #^[</].*$#

--- a/syntax/nerdtree.vim
+++ b/syntax/nerdtree.vim
@@ -35,8 +35,12 @@ exec 'syn match NERDTreeRO # *\zs.*\ze \['.g:NERDTreeGlyphReadOnly.'\]# contains
 
 syn match NERDTreeFlags #^ *\zs\[.\]# containedin=NERDTreeFile,NERDTreeExecFile
 syn match NERDTreeFlags #\[.\]# containedin=NERDTreeDir
-exec 'syn match NERDTreeNodeDelimiters #' . g:NERDTreeNodeDelimiter . '# conceal containedin=NERDTreeFile,NERDTreeDir'
-setlocal conceallevel=2 concealcursor=nvic
+
+"highlighing to conceal the delimiter around the file/dir name
+if has("conceal")
+    exec 'syn match NERDTreeNodeDelimiters #' . g:NERDTreeNodeDelimiter . '# conceal containedin=NERDTreeFile,NERDTreeDir'
+    setlocal conceallevel=2 concealcursor=nvic
+endif
 
 syn match NERDTreeCWD #^[</].*$#
 

--- a/syntax/nerdtree.vim
+++ b/syntax/nerdtree.vim
@@ -35,6 +35,8 @@ exec 'syn match NERDTreeRO # *\zs.*\ze \['.g:NERDTreeGlyphReadOnly.'\]# contains
 
 syn match NERDTreeFlags #^ *\zs\[.\]# containedin=NERDTreeFile,NERDTreeExecFile
 syn match NERDTreeFlags #\[.\]# containedin=NERDTreeDir
+exec 'syn match NERDTreeNodeDelimiters #' . g:NERDTreeNodeDelimiter . '# conceal containedin=NERDTreeFile,NERDTreeDir'
+setlocal conceallevel=2 concealcursor=nvic
 
 syn match NERDTreeCWD #^[</].*$#
 

--- a/syntax/nerdtree.vim
+++ b/syntax/nerdtree.vim
@@ -38,10 +38,10 @@ syn match NERDTreeFlags #\[.\]# containedin=NERDTreeDir
 
 "highlighing to conceal the delimiter around the file/dir name
 if has("conceal")
-    exec 'syn match NERDTreeNodeDelimiters #' . g:NERDTreeNodeDelimiter . '# conceal containedin=NERDTreeFile,NERDTreeLinkFile,NERDTreeRO,NERDTreeDir'
+    exec 'syn match NERDTreeNodeDelimiters #' . g:NERDTreeNodeDelimiter . '# conceal containedin=NERDTreeFile,NERDTreeLinkFile,NERDTreeExecFile,NERDTreeRO,NERDTreeDir'
     setlocal conceallevel=2 concealcursor=nvic
 else
-    exec 'syn match NERDTreeNodeDelimiters #' . g:NERDTreeNodeDelimiter . '# containedin=NERDTreeFile,NERDTreeLinkFile,NERDTreeRO,NERDTreeDir'
+    exec 'syn match NERDTreeNodeDelimiters #' . g:NERDTreeNodeDelimiter . '# containedin=NERDTreeFile,NERDTreeLinkFile,NERDTreeExecFile,NERDTreeRO,NERDTreeDir'
     hi! link NERDTreeNodeDelimiters Ignore
 endif
 


### PR DESCRIPTION
Fixes: #680 #492 #469 #424 #391 #217 

This PR has the potential to fix a bunch of issues. The problem with these issues is related to parsing the file or directory name from the current line of text. In short, I fixed it by surrounding the filename with non-breaking spaces (ASCII code 160), and using that pair of delimiters to find the filename in the text when needed. I also added syntax highlighting to conceal this character, making it appear as if nothing has been added. The advantages to using this character are:

1. It is **very** unlikely to be used in a filename.
1. If `conceal` is not compiled into your Vim, the only side effect is that the tree and trailing flags are pushed over by one extra "space".

There may be cases where this doesn't work so well, though, and some improvements will need to be made to this PR. The one I can think of right away is editing in an environment that doesn't support Unicode characters, or whatever the non-breaking space is. `ssh` comes to mind as a possible trouble spot.

`conceal` was added in 7.3, but with the `if has("conceal")` in the syntax file, we should be ok. It will just have the added spacing indicated above.

I would like to enlist the authors of the related issues to test this fully. Areas I'd like them and others to try are:
- [ ] scenarios listed in the issues
- [ ] gvim
- [ ] console vim
- [ ] using the mouse to interact with NERDTree
- [ ] possible side effects caused to other plugins like
    - [ ] nerdtree-git-plugin
    - [ ] devicons
- [ ] ssh
- [ ] older versions of vim 7.0 - 7.2
- [ ] Windows
- [ ] Linux
- [ ] Mac

Of course, I don't expect everyone to test all these areas, but given enough people we can likely cover them all. 