### PR TITLE
Unzoom NERDTree when opening a file

### DIFF
--- a/lib/nerdtree/opener.vim
+++ b/lib/nerdtree/opener.vim
@@ -244,7 +244,7 @@ endfunction
 
 " FUNCTION: Opener._openFile() {{{1
 function! s:Opener._openFile()
-    if !self._stay && exists("b:NERDTreeZoomed") && b:NERDTreeZoomed
+    if !self._stay && !g:NERDTreeQuitOnOpen && exists("b:NERDTreeZoomed") && b:NERDTreeZoomed
         call b:NERDTree.ui.toggleZoom()
     endif
 

--- a/lib/nerdtree/opener.vim
+++ b/lib/nerdtree/opener.vim
@@ -244,6 +244,9 @@ endfunction
 
 " FUNCTION: Opener._openFile() {{{1
 function! s:Opener._openFile()
+    if !self._stay && exists("b:NERDTreeZoomed") && b:NERDTreeZoomed
+        call b:NERDTree.ui.toggleZoom()
+    endif
 
     if self._reuseWindow()
         return


### PR DESCRIPTION
Implements #15.

IF
1. the user wants NERDTree to stay open (`g:NERDTreeQuitOnOpen=0`),
1. the NERDTree is zoomed, and
1. a file is opened with `o`, `i`, `s`, or `t`

THEN unzoom NERDTree first.

We don't need to unzoom NERDTree if it's going to be closed when opening a file, and chances are the user wants it to remain zoomed the next time it's opened anyway.

`go`, `gi`, `gs`, and `T` do not trigger this new behavior, because focus remains in the
NERDTree.