### PR TITLE
Add new command to open NERDTree in the root of a VCS repository.

### DIFF
--- a/autoload/nerdtree/ui_glue.vim
+++ b/autoload/nerdtree/ui_glue.vim
@@ -570,7 +570,6 @@ endfunction
 " FUNCTION: nerdtree#ui_glue#setupCommands() {{{1
 function! nerdtree#ui_glue#setupCommands()
     command! -n=? -complete=dir -bar NERDTree :call g:NERDTreeCreator.CreateTabTree('<args>')
-    command! -n=? -complete=dir -bar NERDTreeVCS :call g:NERDTreeCreator.CreateTabTreeVCS('<args>')
     command! -n=? -complete=dir -bar NERDTreeToggle :call g:NERDTreeCreator.ToggleTabTree('<args>')
     command! -n=0 -bar NERDTreeClose :call g:NERDTree.Close()
     command! -n=1 -complete=customlist,nerdtree#completeBookmarks -bar NERDTreeFromBookmark call g:NERDTreeCreator.CreateTabTree('<args>')

--- a/autoload/nerdtree/ui_glue.vim
+++ b/autoload/nerdtree/ui_glue.vim
@@ -570,6 +570,7 @@ endfunction
 " FUNCTION: nerdtree#ui_glue#setupCommands() {{{1
 function! nerdtree#ui_glue#setupCommands()
     command! -n=? -complete=dir -bar NERDTree :call g:NERDTreeCreator.CreateTabTree('<args>')
+    command! -n=? -complete=dir -bar NERDTreeVCS :call g:NERDTreeCreator.CreateTabTreeVCS('<args>')
     command! -n=? -complete=dir -bar NERDTreeToggle :call g:NERDTreeCreator.ToggleTabTree('<args>')
     command! -n=0 -bar NERDTreeClose :call g:NERDTree.Close()
     command! -n=1 -complete=customlist,nerdtree#completeBookmarks -bar NERDTreeFromBookmark call g:NERDTreeCreator.CreateTabTree('<args>')

--- a/doc/NERDTree.txt
+++ b/doc/NERDTree.txt
@@ -113,6 +113,7 @@ The following features and functionality are provided by the NERD tree:
     works with Git, Subversion, Mercurial, Bazaar, and Darcs repositories. A
     couple of examples: >
         :NERDTreeVCS /home/marty/nerdtree/doc  (opens /home/marty/nerdtree)
+        :NERDTreeVCS              (opens root of repository containing CWD)
 <
 :NERDTreeFromBookmark <bookmark>                       *:NERDTreeFromBookmark*
     Opens a fresh NERD tree with the root initialized to the dir for

--- a/doc/NERDTree.txt
+++ b/doc/NERDTree.txt
@@ -107,6 +107,13 @@ The following features and functionality are provided by the NERD tree:
         :NERDTree /home/marty/vim7/src
         :NERDTree foo   (foo is the name of a bookmark)
 <
+:NERDTreeVCS [<start-directory> | <bookmark>]                   *:NERDTreeVCS*
+    Like |:NERDTree|, but searches up the directory tree to find the top of
+    the version control system repository, and roots the NERD tree there. It
+    works with Git, Subversion, Mercurial, Bazaar, and Darcs repositories. A
+    couple of examples: >
+        :NERDTreeVCS /home/marty/nerdtree/doc  (opens /home/marty/nerdtree)
+<
 :NERDTreeFromBookmark <bookmark>                       *:NERDTreeFromBookmark*
     Opens a fresh NERD tree with the root initialized to the dir for
     <bookmark>.  The only reason to use this command over :NERDTree is for

--- a/lib/nerdtree/creator.vim
+++ b/lib/nerdtree/creator.vim
@@ -49,7 +49,7 @@ function! s:Creator.CreateTabTreeVCS(name)
     let l:path = self._pathForString(a:name)
     let l:path = self._findParentVCSRoot(l:path)
     let creator = s:Creator.New()
-    call creator.createTabTree(l:path._str())
+    call creator.createTabTree(empty(l:path) ? "" : l:path._str())
 endfunction
 
 " FUNCTION: s:Creator.createTabTree(a:name) {{{1

--- a/lib/nerdtree/creator.vim
+++ b/lib/nerdtree/creator.vim
@@ -33,7 +33,7 @@ function! s:Creator._broadcastInitEvent()
     silent doautocmd User NERDTreeInit
 endfunction
 
-" FUNCTION: s:Creator.BufNamePrefix() {{{2
+" FUNCTION: s:Creator.BufNamePrefix() {{{1
 function! s:Creator.BufNamePrefix()
     return 'NERD_tree_'
 endfunction
@@ -42,6 +42,26 @@ endfunction
 function! s:Creator.CreateTabTree(name)
     let creator = s:Creator.New()
     call creator.createTabTree(a:name)
+endfunction
+
+" FUNCTION: s:Creator.CreateTabTreeVCS(a:name) {{{1
+function! s:Creator.CreateTabTreeVCS(name)
+    let l:path = self._pathForString(a:name)
+    while !empty(l:path) &&
+        \ l:path._str() !~ '^/$' &&
+        \ !isdirectory(l:path._str() . '/.git') &&
+        \ !isdirectory(l:path._str() . '/.svn') &&
+        \ !isdirectory(l:path._str() . '/.hg') &&
+        \ !isdirectory(l:path._str() . '/.bzr') &&
+        \ !isdirectory(l:path._str() . '/_darcs')
+        let l:path = l:path.getParent()
+    endwhile
+    let creator = s:Creator.New()
+    if empty(l:path) || l:path._str() =~ '^/$'
+        call creator.createTabTree(a:name)
+    else
+        call creator.createTabTree(l:path._str())
+    endif
 endfunction
 
 " FUNCTION: s:Creator.createTabTree(a:name) {{{1

--- a/lib/nerdtree/creator.vim
+++ b/lib/nerdtree/creator.vim
@@ -44,14 +44,6 @@ function! s:Creator.CreateTabTree(name)
     call creator.createTabTree(a:name)
 endfunction
 
-" FUNCTION: s:Creator.CreateTabTreeVCS(a:name) {{{1
-function! s:Creator.CreateTabTreeVCS(name)
-    let l:path = self._pathForString(a:name)
-    let l:path = self._findParentVCSRoot(l:path)
-    let creator = s:Creator.New()
-    call creator.createTabTree(empty(l:path) ? "" : l:path._str())
-endfunction
-
 " FUNCTION: s:Creator.createTabTree(a:name) {{{1
 " name: the name of a bookmark or a directory
 function! s:Creator.createTabTree(name)
@@ -208,23 +200,6 @@ function! s:Creator._createTreeWin()
     endif
 
     setlocal winfixwidth
-endfunction
-
-" FUNCTION: s:Creator._findParentVCSRoot(a:path) {{{1
-" Finds the root version control system folder of the given path. If a:path is
-" not part of a repository, return the original path.
-function! s:Creator._findParentVCSRoot(path)
-    let l:path = a:path
-    while !empty(l:path) &&
-        \ l:path._str() !~ '^\(\a:\\\|\/\)$' &&
-        \ !isdirectory(l:path._str() . '/.git') &&
-        \ !isdirectory(l:path._str() . '/.svn') &&
-        \ !isdirectory(l:path._str() . '/.hg') &&
-        \ !isdirectory(l:path._str() . '/.bzr') &&
-        \ !isdirectory(l:path._str() . '/_darcs')
-        let l:path = l:path.getParent()
-    endwhile
-    return (empty(l:path) || l:path._str() =~ '^\(\a:\\\|\/\)$') ? a:path : l:path
 endfunction
 
 " FUNCTION: s:Creator._isBufHidden(nr) {{{1

--- a/lib/nerdtree/creator.vim
+++ b/lib/nerdtree/creator.vim
@@ -47,21 +47,9 @@ endfunction
 " FUNCTION: s:Creator.CreateTabTreeVCS(a:name) {{{1
 function! s:Creator.CreateTabTreeVCS(name)
     let l:path = self._pathForString(a:name)
-    while !empty(l:path) &&
-        \ l:path._str() !~ '^/$' &&
-        \ !isdirectory(l:path._str() . '/.git') &&
-        \ !isdirectory(l:path._str() . '/.svn') &&
-        \ !isdirectory(l:path._str() . '/.hg') &&
-        \ !isdirectory(l:path._str() . '/.bzr') &&
-        \ !isdirectory(l:path._str() . '/_darcs')
-        let l:path = l:path.getParent()
-    endwhile
+    let l:path = self._findParentVCSRoot(l:path)
     let creator = s:Creator.New()
-    if empty(l:path) || l:path._str() =~ '^/$'
-        call creator.createTabTree(a:name)
-    else
-        call creator.createTabTree(l:path._str())
-    endif
+    call creator.createTabTree(l:path._str())
 endfunction
 
 " FUNCTION: s:Creator.createTabTree(a:name) {{{1
@@ -220,6 +208,23 @@ function! s:Creator._createTreeWin()
     endif
 
     setlocal winfixwidth
+endfunction
+
+" FUNCTION: s:Creator._findParentVCSRoot(a:path) {{{1
+" Finds the root version control system folder of the given path. If a:path is
+" not part of a repository, return the original path.
+function! s:Creator._findParentVCSRoot(path)
+    let l:path = a:path
+    while !empty(l:path) &&
+        \ l:path._str() !~ '^\(\a:\\\|\/\)$' &&
+        \ !isdirectory(l:path._str() . '/.git') &&
+        \ !isdirectory(l:path._str() . '/.svn') &&
+        \ !isdirectory(l:path._str() . '/.hg') &&
+        \ !isdirectory(l:path._str() . '/.bzr') &&
+        \ !isdirectory(l:path._str() . '/_darcs')
+        let l:path = l:path.getParent()
+    endwhile
+    return (empty(l:path) || l:path._str() =~ '^\(\a:\\\|\/\)$') ? a:path : l:path
 endfunction
 
 " FUNCTION: s:Creator._isBufHidden(nr) {{{1

--- a/nerdtree_plugin/vcs.vim
+++ b/nerdtree_plugin/vcs.vim
@@ -1,3 +1,15 @@
+" ============================================================================
+" File:        vcs.vim
+" Description: NERDTree plugin that provides a command to open on the root of
+"              a version control system repository.
+" Maintainer:  Phil Runninger
+" License:     This program is free software. It comes without any warranty,
+"              to the extent permitted by applicable law. You can redistribute
+"              it and/or modify it under the terms of the Do What The Fuck You
+"              Want To Public License, Version 2, as published by Sam Hocevar.
+"              See http://sam.zoy.org/wtfpl/COPYING for more details.
+"
+" ============================================================================
 command! -n=? -complete=dir -bar NERDTreeVCS :call <SID>CreateTabTreeVCS('<args>')
 
 " FUNCTION: s:CreateTabTreeVCS(a:name) {{{1

--- a/nerdtree_plugin/vcs.vim
+++ b/nerdtree_plugin/vcs.vim
@@ -1,0 +1,26 @@
+command! -n=? -complete=dir -bar NERDTreeVCS :call <SID>CreateTabTreeVCS('<args>')
+
+" FUNCTION: s:CreateTabTreeVCS(a:name) {{{1
+function! s:CreateTabTreeVCS(name)
+    let l:path = g:NERDTreeCreator._pathForString(a:name)
+    let l:path = s:FindParentVCSRoot(l:path)
+    call g:NERDTreeCreator.createTabTree(empty(l:path) ? "" : l:path._str())
+endfunction
+
+" FUNCTION: s:FindParentVCSRoot(a:path) {{{1
+" Finds the root version control system folder of the given path. If a:path is
+" not part of a repository, return the original path.
+function! s:FindParentVCSRoot(path)
+    let l:path = a:path
+    while !empty(l:path) &&
+        \ l:path._str() !~ '^\(\a:\\\|\/\)$' &&
+        \ !isdirectory(l:path._str() . '/.git') &&
+        \ !isdirectory(l:path._str() . '/.svn') &&
+        \ !isdirectory(l:path._str() . '/.hg') &&
+        \ !isdirectory(l:path._str() . '/.bzr') &&
+        \ !isdirectory(l:path._str() . '/_darcs')
+        let l:path = l:path.getParent()
+    endwhile
+    return (empty(l:path) || l:path._str() =~ '^\(\a:\\\|\/\)$') ? a:path : l:path
+endfunction
+


### PR DESCRIPTION
Implements #335 

I'm not sure this is the best way to implement this request. It uses a new command - `:NERDTreeVCS`. Another way would be to add an option similar to **Ctrl-P**'s `g:ctrlp_working_path_mode`.

@lifecrisis , Do you have a preference?