### PR TITLE
Fix opening sub-directories that have commas in their name.

### DIFF
--- a/lib/nerdtree/tree_dir_node.vim
+++ b/lib/nerdtree/tree_dir_node.vim
@@ -247,7 +247,7 @@ function! s:TreeDirNode._glob(pattern, all)
     if self.path.str() == getcwd()
         let l:pathSpec = ','
     else
-        let l:pathSpec = fnamemodify(self.path.str({'format': 'Glob'}), ':.')
+        let l:pathSpec = escape(fnamemodify(self.path.str({'format': 'Glob'}), ':.'), ',')
 
         " On Windows, the drive letter may be removed by "fnamemodify()".
         if nerdtree#runningWindows() && l:pathSpec[0] == g:NERDTreePath.Slash()


### PR DESCRIPTION
Fixed #314 

The key to fixing this was in the help file entry for the `globpath()` function. If the path argument contains a comma, it will cause `globpath()` to search in multiple non-existent directories.