### PR TITLE
Do a case sensitive comparison of new/existing buffers.

### DIFF
--- a/lib/nerdtree/path.vim
+++ b/lib/nerdtree/path.vim
@@ -817,7 +817,7 @@ function! s:Path.tabnr()
     let str = self.str()
     for t in range(tabpagenr('$'))
         for b in tabpagebuflist(t+1)
-            if str == expand('#' . b . ':p')
+            if str ==# expand('#' . b . ':p')
                 return t+1
             endif
         endfor


### PR DESCRIPTION
Fixes: #377 

When NERTDtree opens a file, it compares this new file to all open
buffers to see if it's already open. If the user has 'ignorecase' turned
on then the comparison of "file" and "File" says they're the same, and
NERDTree won't reopen the file. This commit forces a case sensitive
comparison by using the ==# operator.