### PR TITLE
Add custom bookmark prefix

### DIFF
--- a/lib/nerdtree/bookmark.vim
+++ b/lib/nerdtree/bookmark.vim
@@ -190,7 +190,7 @@ endfunction
 " returns the Bookmark the cursor is over, or {}
 function! s:Bookmark.GetSelected()
     let line = getline(".")
-    let name = substitute(line, '^>\(.\{-}\) .\+$', '\1', '')
+    let name = substitute(line, '^' . g:NERDTreeBookmarksPrefix . '\(.\{-}\) .\+$', '\1', '')
     if name != line
         try
             return s:Bookmark.BookmarkFor(name)
@@ -292,7 +292,7 @@ function! s:Bookmark.str()
         endwhile
         let pathStr = '<' . pathStr
     endif
-    return '>' . self.name . ' ' . pathStr
+    return g:NERDTreeBookmarksPrefix . self.name . ' ' . pathStr
 endfunction
 
 " FUNCTION: Bookmark.toRoot(nerdtree) {{{1

--- a/plugin/NERD_tree.vim
+++ b/plugin/NERD_tree.vim
@@ -56,6 +56,7 @@ if !exists("g:NERDTreeIgnore")
 endif
 call s:initVariable("g:NERDTreeBookmarksFile", expand('$HOME') . '/.NERDTreeBookmarks')
 call s:initVariable("g:NERDTreeBookmarksSort", 1)
+call s:initVariable("g:NERDTreeBookmarksPrefix", "— ")
 call s:initVariable("g:NERDTreeHighlightCursorline", 1)
 call s:initVariable("g:NERDTreeHijackNetrw", 1)
 call s:initVariable('g:NERDTreeMarkBookmarks', 1)

--- a/plugin/NERD_tree.vim
+++ b/plugin/NERD_tree.vim
@@ -56,7 +56,7 @@ if !exists("g:NERDTreeIgnore")
 endif
 call s:initVariable("g:NERDTreeBookmarksFile", expand('$HOME') . '/.NERDTreeBookmarks')
 call s:initVariable("g:NERDTreeBookmarksSort", 1)
-call s:initVariable("g:NERDTreeBookmarksPrefix", "— ")
+call s:initVariable("g:NERDTreeBookmarksPrefix", ">")
 call s:initVariable("g:NERDTreeHighlightCursorline", 1)
 call s:initVariable("g:NERDTreeHijackNetrw", 1)
 call s:initVariable('g:NERDTreeMarkBookmarks', 1)

--- a/syntax/nerdtree.vim
+++ b/syntax/nerdtree.vim
@@ -42,10 +42,10 @@ syn match NERDTreeCWD #^[</].*$#
 syn match NERDTreeBookmark # {.*}#hs=s+1
 
 "highlighting for the bookmarks table
-syn match NERDTreeBookmarksLeader #^>#
+exec 'syn match NERDTreeBookmarksLeader #^'.g:NERDTreeBookmarksPrefix.'>#'
 syn match NERDTreeBookmarksHeader #^>-\+Bookmarks-\+$# contains=NERDTreeBookmarksLeader
-syn match NERDTreeBookmarkName #^>.\{-} #he=e-1 contains=NERDTreeBookmarksLeader
-syn match NERDTreeBookmark #^>.*$# contains=NERDTreeBookmarksLeader,NERDTreeBookmarkName,NERDTreeBookmarksHeader
+exec 'syn match NERDTreeBookmarkName #^'.g:NERDTreeBookmarksPrefix.'.\{-} #he=e-1 contains=NERDTreeBookmarksLeader'
+exec 'syn match NERDTreeBookmark #^'.g:NERDTreeBookmarksPrefix.'.*$# contains=NERDTreeBookmarksLeader,NERDTreeBookmarkName,NERDTreeBookmarksHeader'
 
 hi def link NERDTreePart Special
 hi def link NERDTreePartFile Type


### PR DESCRIPTION
Allows a custom icon or prefix for bookmarks:

![image](https://user-images.githubusercontent.com/724363/44466386-75c7e900-a620-11e8-8965-fb50eed1e535.png)

This custom behavior can be set by
```vim
let g:NERDTreeBookmarksPrefix = '# '
```