### PR TITLE
Use <count>tabnext instead of <count>gt to allow users to remap gt.

### DIFF
--- a/lib/nerdtree/opener.vim
+++ b/lib/nerdtree/opener.vim
@@ -233,7 +233,6 @@ endfunction
 
 " FUNCTION: Opener.open(target) {{{1
 function! s:Opener.open(target)
-
     if self._path.isDirectory
         call self._openDirectory(a:target)
         return
@@ -303,7 +302,7 @@ endfunction
 
 " FUNCTION: Opener._restoreCursorPos() {{{1
 function! s:Opener._restoreCursorPos()
-    call nerdtree#exec('normal ' . self._tabnr . 'gt')
+    call nerdtree#exec(self._tabnr . 'tabnext')
     call nerdtree#exec(bufwinnr(self._bufnr) . 'wincmd w')
 endfunction
 
@@ -332,7 +331,7 @@ function! s:Opener._reuseWindow()
     let tabnr = self._path.tabnr()
     if tabnr
         call self._checkToCloseTree(1)
-        call nerdtree#exec('normal! ' . tabnr . 'gt')
+        call nerdtree#exec(tabnr . 'tabnext')
         let winnr = bufwinnr('^' . self._path.str() . '$')
         call nerdtree#exec(winnr . "wincmd w")
         return 1


### PR DESCRIPTION
Fixes #762 

NERDTree was using the `<count>gt` command to switch tabs. So, if the users had remapped `gt`, that would be used instead of the original functionality of `gt`. Fortunately, `<count>tabnext` does the same thing, so this simple fix replaces `gt` with `tabnext`.