### PR TITLE
NERDTreeCWD: reset CWD if changed by NERDTreeFocus

### DIFF
--- a/autoload/nerdtree/ui_glue.vim
+++ b/autoload/nerdtree/ui_glue.vim
@@ -142,18 +142,9 @@ function! s:chRoot(node)
 endfunction
 
 " FUNCTION: s:nerdtree#ui_glue#chRootCwd() {{{1
-" changes the current root to CWD
+" Change the NERDTree root to match the current working directory.
 function! nerdtree#ui_glue#chRootCwd()
-    try
-        let cwd = g:NERDTreePath.New(getcwd())
-    catch /^NERDTree.InvalidArgumentsError/
-        call nerdtree#echo("current directory does not exist.")
-        return
-    endtry
-    if cwd.str() == g:NERDTreeFileNode.GetRootForTab().path.str()
-       return
-    endif
-    call s:chRoot(g:NERDTreeDirNode.New(cwd, b:NERDTree))
+    NERDTreeCWD
 endfunction
 
 " FUNCTION: nnerdtree#ui_glue#clearBookmarks(bookmarks) {{{1

--- a/doc/NERDTree.txt
+++ b/doc/NERDTree.txt
@@ -142,8 +142,8 @@ The following features and functionality are provided by the NERD tree:
     current tab does not exist, a new one will be initialized.
 
 :NERDTreeCWD                                                    *:NERDTreeCWD*
-    Change tree root to current directory. If no NERD tree exists for this
-    tab, a new tree will be opened.
+    Change the NERDTree root to the current working directory. If no NERDTree
+    exists for this tab, a new one is opened.
 
 ------------------------------------------------------------------------------
 2.2. Bookmarks                                             *NERDTreeBookmarks*

--- a/doc/NERDTree.txt
+++ b/doc/NERDTree.txt
@@ -142,8 +142,8 @@ The following features and functionality are provided by the NERD tree:
     current tab does not exist, a new one will be initialized.
 
 :NERDTreeCWD                                                    *:NERDTreeCWD*
-    Change the NERDTree root to the current working directory. If no NERDTree
-    exists for this tab, a new one is opened.
+    Change the NERDTree root to the current working directory.  If no
+    NERDTree exists for this tab, a new one is opened.
 
 ------------------------------------------------------------------------------
 2.2. Bookmarks                                             *NERDTreeBookmarks*
@@ -522,7 +522,7 @@ Default key: cd
 Map option: NERDTreeMapChdir
 Applies to: files and directories.
 
-Change vims current working directory to that of the selected node.
+Change Vim's current working directory to that of the selected node.
 
 ------------------------------------------------------------------------------
                                                                  *NERDTree-CD*
@@ -530,7 +530,7 @@ Default key: CD
 Map option: NERDTreeMapCWD
 Applies to: no restrictions.
 
-Change tree root to vims current working directory.
+Change the NERDTree root to Vim's current working directory.
 
 ------------------------------------------------------------------------------
                                                                   *NERDTree-I*

--- a/plugin/NERD_tree.vim
+++ b/plugin/NERD_tree.vim
@@ -202,7 +202,11 @@ function! NERDTreeFocus()
 endfunction
 
 function! NERDTreeCWD()
+    let l:cwd = getcwd()
     call NERDTreeFocus()
+    if l:cwd != getcwd()
+        exec 'cd '.l:cwd
+    endif
     call nerdtree#ui_glue#chRootCwd()
 endfunction
 

--- a/plugin/NERD_tree.vim
+++ b/plugin/NERD_tree.vim
@@ -203,6 +203,11 @@ endfunction
 
 function! NERDTreeCWD()
 
+    if empty(getcwd())
+        call nerdtree#echoWarning('current directory does not exist')
+        return
+    endif
+
     try
         let l:cwdPath = g:NERDTreePath.New(getcwd())
     catch /^NERDTree.InvalidArgumentsError/

--- a/plugin/NERD_tree.vim
+++ b/plugin/NERD_tree.vim
@@ -202,12 +202,15 @@ function! NERDTreeFocus()
 endfunction
 
 function! NERDTreeCWD()
-    let l:cwd = getcwd()
+    let l:cwdPath = g:NERDTreePath.New(getcwd())
     call NERDTreeFocus()
-    if l:cwd != getcwd()
-        exec 'cd '.l:cwd
+
+    if b:NERDTree.root.path.equals(l:cwdPath)
+        return
     endif
-    call nerdtree#ui_glue#chRootCwd()
+
+    let l:newRoot = g:NERDTreeFileNode.New(l:cwdPath, b:NERDTree)
+    call b:NERDTree.changeRoot(l:newRoot)
 endfunction
 
 function! NERDTreeAddPathFilter(callback)

--- a/plugin/NERD_tree.vim
+++ b/plugin/NERD_tree.vim
@@ -218,6 +218,7 @@ function! NERDTreeCWD()
 
     let l:newRoot = g:NERDTreeFileNode.New(l:cwdPath, b:NERDTree)
     call b:NERDTree.changeRoot(l:newRoot)
+    normal! ^
 endfunction
 
 function! NERDTreeAddPathFilter(callback)

--- a/plugin/NERD_tree.vim
+++ b/plugin/NERD_tree.vim
@@ -202,7 +202,14 @@ function! NERDTreeFocus()
 endfunction
 
 function! NERDTreeCWD()
-    let l:cwdPath = g:NERDTreePath.New(getcwd())
+
+    try
+        let l:cwdPath = g:NERDTreePath.New(getcwd())
+    catch /^NERDTree.InvalidArgumentsError/
+        call nerdtree#echoWarning('current directory does not exist')
+        return
+    endtry
+
     call NERDTreeFocus()
 
     if b:NERDTree.root.path.equals(l:cwdPath)


### PR DESCRIPTION
Fixes #855. 

When the user has `'autochdir'` turned on, opening a new NERDTree will
cause the current working directory to change. To prevent this
happening, remember the CWD and reset it if NERDTreeFocus caused it to
change.