### PR TITLE
Function "s:UI.getLineNum()" doesn't always work on cascades.

### DIFF
--- a/lib/nerdtree/ui.vim
+++ b/lib/nerdtree/ui.vim
@@ -228,13 +228,12 @@ function! s:UI.getLineNum(node)
                 return l:lineNumber
             endif
 
-            if stridx(l:fullPath, l:currentPath) == 0
-
-                if strpart(l:fullPath, len(l:currentPath)-1,1) ==# '/'
-                    let l:currentLine = substitute(l:currentLine, '/ *$', '', '')
-                    call add(l:pathComponents, l:currentLine)
-                    let l:currentPathComponent += 1
-                endif
+            " Otherwise: If the full path starts with the current path and the
+            " current path is a directory, we add a new path component.
+            if stridx(l:fullPath, l:currentPath) == 0 && l:currentPath[-1:] ==# '/'
+                let l:currentLine = substitute(l:currentLine, '/\s*$', '', '')
+                call add(l:pathComponents, l:currentLine)
+                let l:currentPathComponent += 1
             endif
         endif
     endfor

--- a/lib/nerdtree/ui.vim
+++ b/lib/nerdtree/ui.vim
@@ -208,7 +208,7 @@ function! s:UI.getLineNum(file_node)
     " the index of the component we are searching for
     let curPathComponent = 1
 
-    let fullpath = a:file_node.path.str({'format': 'UI'})
+    let l:fullPath = a:file_node.path.str({'format': 'UI'})
 
     for l:lineNumber in range(self.getRootLineNum(), line('$'))
         let l:currentLine = getline(l:lineNumber)
@@ -218,13 +218,13 @@ function! s:UI.getLineNum(file_node)
             let l:currentLine = self._stripMarkup(l:currentLine)
             let l:currentPath =  join(pathcomponents, '/') . '/' . l:currentLine
 
-            if stridx(fullpath, l:currentPath, 0) ==# 0
-                if fullpath ==# l:currentPath || strpart(fullpath, len(l:currentPath)-1,1) ==# '/'
+            if stridx(l:fullPath, l:currentPath, 0) ==# 0
+                if l:fullPath ==# l:currentPath || strpart(l:fullPath, len(l:currentPath)-1,1) ==# '/'
                     let l:currentLine = substitute(l:currentLine, '/ *$', '', '')
                     call add(pathcomponents, l:currentLine)
                     let curPathComponent = curPathComponent + 1
 
-                    if fullpath ==# l:currentPath
+                    if l:fullPath ==# l:currentPath
                         return l:lineNumber
                     endif
                 endif

--- a/lib/nerdtree/ui.vim
+++ b/lib/nerdtree/ui.vim
@@ -218,9 +218,15 @@ function! s:UI.getLineNum(file_node)
             let l:currentLine = self._stripMarkup(l:currentLine)
             let l:currentPath =  join(pathcomponents, '/') . '/' . l:currentLine
 
-            " If the current path "starts with" the full path, then the paths
-            " are equal or we have a cascade containing the full path.
-            if stridx(l:currentPath, l:fullPath) == 0
+            " Directories: If the current path "starts with" the full path,
+            " then either the paths are equal or the line is a cascade
+            " containing the full path.
+            if l:fullPath[-1:] ==# '/' && stridx(l:currentPath, l:fullPath) == 0
+                return l:lineNumber
+            endif
+
+            " Files: The paths must exactly match.
+            if l:currentPath ==# l:fullPath
                 return l:lineNumber
             endif
 

--- a/lib/nerdtree/ui.vim
+++ b/lib/nerdtree/ui.vim
@@ -194,12 +194,12 @@ function! s:UI.getPath(ln)
     return toReturn
 endfunction
 
-" FUNCTION: s:UI.getLineNum(file_node) {{{1
+" FUNCTION: s:UI.getLineNum(node) {{{1
 " Return the line number where the given node is rendered.  Return -1 if the
 " given node is not visible.
-function! s:UI.getLineNum(file_node)
+function! s:UI.getLineNum(node)
 
-    if a:file_node.isRoot()
+    if a:node.isRoot()
         return self.getRootLineNum()
     endif
 
@@ -208,7 +208,7 @@ function! s:UI.getLineNum(file_node)
     " the index of the component we are searching for
     let curPathComponent = 1
 
-    let l:fullPath = a:file_node.path.str({'format': 'UI'})
+    let l:fullPath = a:node.path.str({'format': 'UI'})
 
     for l:lineNumber in range(self.getRootLineNum(), line('$'))
         let l:currentLine = getline(l:lineNumber)

--- a/lib/nerdtree/ui.vim
+++ b/lib/nerdtree/ui.vim
@@ -194,15 +194,16 @@ function! s:UI.getPath(ln)
     return toReturn
 endfunction
 
-" FUNCTION: s:UI.getLineNum(file_node){{{1
-" returns the line number this node is rendered on, or -1 if it isnt rendered
+" FUNCTION: s:UI.getLineNum(file_node) {{{1
+" Return the line number where the given node is rendered.  Return -1 if the
+" given node is not visible.
 function! s:UI.getLineNum(file_node)
-    " if the node is the root then return the root line no.
+
     if a:file_node.isRoot()
         return self.getRootLineNum()
     endif
 
-    let totalLines = line("$")
+    let totalLines = line('$')
 
     " the path components we have matched so far
     let pathcomponents = [substitute(self.nerdtree.root.path.str({'format': 'UI'}), '/ *$', '', '')]

--- a/lib/nerdtree/ui.vim
+++ b/lib/nerdtree/ui.vim
@@ -218,15 +218,18 @@ function! s:UI.getLineNum(file_node)
             let l:currentLine = self._stripMarkup(l:currentLine)
             let l:currentPath =  join(pathcomponents, '/') . '/' . l:currentLine
 
+            " NOTE: If the current path "starts with" the full path, then the
+            " paths are equal or we have a cascade that has the full path.
+            if stridx(l:currentPath, l:fullPath) == 0
+                return l:lineNumber
+            endif
+
             if stridx(l:fullPath, l:currentPath, 0) ==# 0
+
                 if l:fullPath ==# l:currentPath || strpart(l:fullPath, len(l:currentPath)-1,1) ==# '/'
                     let l:currentLine = substitute(l:currentLine, '/ *$', '', '')
                     call add(pathcomponents, l:currentLine)
                     let curPathComponent = curPathComponent + 1
-
-                    if l:fullPath ==# l:currentPath
-                        return l:lineNumber
-                    endif
                 endif
             endif
         endif

--- a/lib/nerdtree/ui.vim
+++ b/lib/nerdtree/ui.vim
@@ -204,9 +204,9 @@ function! s:UI.getLineNum(node)
     endif
 
     " the path components we have matched so far
-    let pathcomponents = [substitute(self.nerdtree.root.path.str({'format': 'UI'}), '/\s*$', '', '')]
+    let l:pathComponents = [substitute(self.nerdtree.root.path.str({'format': 'UI'}), '/\s*$', '', '')]
     " the index of the component we are searching for
-    let curPathComponent = 1
+    let l:currentPathComponent = 1
 
     let l:fullPath = a:node.path.str({'format': 'UI'})
 
@@ -214,9 +214,9 @@ function! s:UI.getLineNum(node)
         let l:currentLine = getline(l:lineNumber)
         let l:indentLevel = self._indentLevelFor(l:currentLine)
 
-        if l:indentLevel ==# curPathComponent
+        if l:indentLevel ==# l:currentPathComponent
             let l:currentLine = self._stripMarkup(l:currentLine)
-            let l:currentPath =  join(pathcomponents, '/') . '/' . l:currentLine
+            let l:currentPath =  join(l:pathComponents, '/') . '/' . l:currentLine
 
             " Directories: If the current path "starts with" the full path,
             " then either the paths are equal or the line is a cascade
@@ -234,8 +234,8 @@ function! s:UI.getLineNum(node)
 
                 if l:fullPath ==# l:currentPath || strpart(l:fullPath, len(l:currentPath)-1,1) ==# '/'
                     let l:currentLine = substitute(l:currentLine, '/ *$', '', '')
-                    call add(pathcomponents, l:currentLine)
-                    let curPathComponent = curPathComponent + 1
+                    call add(l:pathComponents, l:currentLine)
+                    let l:currentPathComponent += 1
                 endif
             endif
         endif

--- a/lib/nerdtree/ui.vim
+++ b/lib/nerdtree/ui.vim
@@ -212,7 +212,7 @@ function! s:UI.getLineNum(node)
         let l:currentLine = getline(l:lineNumber)
         let l:indentLevel = self._indentLevelFor(l:currentLine)
 
-        if l:indentLevel ==# l:currentPathComponent
+        if l:indentLevel == l:currentPathComponent
             let l:currentLine = self._stripMarkup(l:currentLine)
             let l:currentPath =  join(l:pathComponents, '/') . '/' . l:currentLine
 
@@ -228,7 +228,7 @@ function! s:UI.getLineNum(node)
                 return l:lineNumber
             endif
 
-            if stridx(l:fullPath, l:currentPath, 0) ==# 0
+            if stridx(l:fullPath, l:currentPath) == 0
 
                 if strpart(l:fullPath, len(l:currentPath)-1,1) ==# '/'
                     let l:currentLine = substitute(l:currentLine, '/ *$', '', '')

--- a/lib/nerdtree/ui.vim
+++ b/lib/nerdtree/ui.vim
@@ -211,17 +211,17 @@ function! s:UI.getLineNum(file_node)
     let fullpath = a:file_node.path.str({'format': 'UI'})
 
     for l:lineNumber in range(self.getRootLineNum(), line('$'))
-        let curLine = getline(l:lineNumber)
-        let indent = self._indentLevelFor(curLine)
+        let l:currentLine = getline(l:lineNumber)
+        let indent = self._indentLevelFor(l:currentLine)
 
         if indent ==# curPathComponent
-            let curLine = self._stripMarkup(curLine)
+            let l:currentLine = self._stripMarkup(l:currentLine)
 
-            let curPath =  join(pathcomponents, '/') . '/' . curLine
+            let curPath =  join(pathcomponents, '/') . '/' . l:currentLine
             if stridx(fullpath, curPath, 0) ==# 0
                 if fullpath ==# curPath || strpart(fullpath, len(curPath)-1,1) ==# '/'
-                    let curLine = substitute(curLine, '/ *$', '', '')
-                    call add(pathcomponents, curLine)
+                    let l:currentLine = substitute(l:currentLine, '/ *$', '', '')
+                    call add(pathcomponents, l:currentLine)
                     let curPathComponent = curPathComponent + 1
 
                     if fullpath ==# curPath

--- a/lib/nerdtree/ui.vim
+++ b/lib/nerdtree/ui.vim
@@ -212,15 +212,15 @@ function! s:UI.getLineNum(file_node)
 
     let fullpath = a:file_node.path.str({'format': 'UI'})
 
-    let lnum = self.getRootLineNum()
-    while lnum > 0
-        let lnum = lnum + 1
+    let l:lineNumber = self.getRootLineNum()
+    while l:lineNumber > 0
+        let l:lineNumber = l:lineNumber + 1
         " have we reached the bottom of the tree?
-        if lnum ==# totalLines+1
+        if l:lineNumber ==# totalLines+1
             return -1
         endif
 
-        let curLine = getline(lnum)
+        let curLine = getline(l:lineNumber)
 
         let indent = self._indentLevelFor(curLine)
         if indent ==# curPathComponent
@@ -234,7 +234,7 @@ function! s:UI.getLineNum(file_node)
                     let curPathComponent = curPathComponent + 1
 
                     if fullpath ==# curPath
-                        return lnum
+                        return l:lineNumber
                     endif
                 endif
             endif

--- a/lib/nerdtree/ui.vim
+++ b/lib/nerdtree/ui.vim
@@ -212,29 +212,31 @@ function! s:UI.getLineNum(node)
         let l:currentLine = getline(l:lineNumber)
         let l:indentLevel = self._indentLevelFor(l:currentLine)
 
-        if l:indentLevel == l:currentPathComponent
-            let l:currentLine = self._stripMarkup(l:currentLine)
-            let l:currentPath =  join(l:pathComponents, '/') . '/' . l:currentLine
+        if l:indentLevel != l:currentPathComponent
+            continue
+        endif
 
-            " Directories: If the current path "starts with" the full path,
-            " then either the paths are equal or the line is a cascade
-            " containing the full path.
-            if l:fullPath[-1:] ==# '/' && stridx(l:currentPath, l:fullPath) == 0
-                return l:lineNumber
-            endif
+        let l:currentLine = self._stripMarkup(l:currentLine)
+        let l:currentPath =  join(l:pathComponents, '/') . '/' . l:currentLine
 
-            " Files: The paths must exactly match.
-            if l:currentPath ==# l:fullPath
-                return l:lineNumber
-            endif
+        " Directories: If the current path "starts with" the full path,
+        " then either the paths are equal or the line is a cascade
+        " containing the full path.
+        if l:fullPath[-1:] == '/' && stridx(l:currentPath, l:fullPath) == 0
+            return l:lineNumber
+        endif
 
-            " Otherwise: If the full path starts with the current path and the
-            " current path is a directory, we add a new path component.
-            if stridx(l:fullPath, l:currentPath) == 0 && l:currentPath[-1:] ==# '/'
-                let l:currentLine = substitute(l:currentLine, '/\s*$', '', '')
-                call add(l:pathComponents, l:currentLine)
-                let l:currentPathComponent += 1
-            endif
+        " Files: The paths must exactly match.
+        if l:currentPath ==# l:fullPath
+            return l:lineNumber
+        endif
+
+        " Otherwise: If the full path starts with the current path and the
+        " current path is a directory, we add a new path component.
+        if stridx(l:fullPath, l:currentPath) == 0 && l:currentPath[-1:] == '/'
+            let l:currentLine = substitute(l:currentLine, '/\s*$', '', '')
+            call add(l:pathComponents, l:currentLine)
+            let l:currentPathComponent += 1
         endif
     endfor
 

--- a/lib/nerdtree/ui.vim
+++ b/lib/nerdtree/ui.vim
@@ -219,15 +219,15 @@ function! s:UI.getLineNum(node)
         let l:currentLine = self._stripMarkup(l:currentLine)
         let l:currentPath =  join(l:pathComponents, '/') . '/' . l:currentLine
 
-        " Directories: If the current path "starts with" the full path,
-        " then either the paths are equal or the line is a cascade
-        " containing the full path.
+        " Directories: If the current path "starts with" the full path, then
+        " either the paths are equal or the line is a cascade containing the
+        " full path.
         if l:fullPath[-1:] == '/' && stridx(l:currentPath, l:fullPath) == 0
             return l:lineNumber
         endif
 
         " Files: The paths must exactly match.
-        if l:currentPath ==# l:fullPath
+        if l:fullPath ==# l:currentPath
             return l:lineNumber
         endif
 

--- a/lib/nerdtree/ui.vim
+++ b/lib/nerdtree/ui.vim
@@ -203,8 +203,6 @@ function! s:UI.getLineNum(file_node)
         return self.getRootLineNum()
     endif
 
-    let totalLines = line('$')
-
     " the path components we have matched so far
     let pathcomponents = [substitute(self.nerdtree.root.path.str({'format': 'UI'}), '/ *$', '', '')]
     " the index of the component we are searching for
@@ -212,17 +210,10 @@ function! s:UI.getLineNum(file_node)
 
     let fullpath = a:file_node.path.str({'format': 'UI'})
 
-    let l:lineNumber = self.getRootLineNum()
-    while l:lineNumber > 0
-        let l:lineNumber = l:lineNumber + 1
-        " have we reached the bottom of the tree?
-        if l:lineNumber ==# totalLines+1
-            return -1
-        endif
-
+    for l:lineNumber in range(self.getRootLineNum(), line('$'))
         let curLine = getline(l:lineNumber)
-
         let indent = self._indentLevelFor(curLine)
+
         if indent ==# curPathComponent
             let curLine = self._stripMarkup(curLine)
 
@@ -239,7 +230,8 @@ function! s:UI.getLineNum(file_node)
                 endif
             endif
         endif
-    endwhile
+    endfor
+
     return -1
 endfunction
 

--- a/lib/nerdtree/ui.vim
+++ b/lib/nerdtree/ui.vim
@@ -208,7 +208,7 @@ function! s:UI.getLineNum(node)
 
     let l:fullPath = a:node.path.str({'format': 'UI'})
 
-    for l:lineNumber in range(self.getRootLineNum(), line('$'))
+    for l:lineNumber in range(self.getRootLineNum() + 1, line('$'))
         let l:currentLine = getline(l:lineNumber)
         let l:indentLevel = self._indentLevelFor(l:currentLine)
 

--- a/lib/nerdtree/ui.vim
+++ b/lib/nerdtree/ui.vim
@@ -230,7 +230,7 @@ function! s:UI.getLineNum(node)
 
             if stridx(l:fullPath, l:currentPath, 0) ==# 0
 
-                if l:fullPath ==# l:currentPath || strpart(l:fullPath, len(l:currentPath)-1,1) ==# '/'
+                if strpart(l:fullPath, len(l:currentPath)-1,1) ==# '/'
                     let l:currentLine = substitute(l:currentLine, '/ *$', '', '')
                     call add(l:pathComponents, l:currentLine)
                     let l:currentPathComponent += 1

--- a/lib/nerdtree/ui.vim
+++ b/lib/nerdtree/ui.vim
@@ -216,15 +216,15 @@ function! s:UI.getLineNum(file_node)
 
         if indent ==# curPathComponent
             let l:currentLine = self._stripMarkup(l:currentLine)
+            let l:currentPath =  join(pathcomponents, '/') . '/' . l:currentLine
 
-            let curPath =  join(pathcomponents, '/') . '/' . l:currentLine
-            if stridx(fullpath, curPath, 0) ==# 0
-                if fullpath ==# curPath || strpart(fullpath, len(curPath)-1,1) ==# '/'
+            if stridx(fullpath, l:currentPath, 0) ==# 0
+                if fullpath ==# l:currentPath || strpart(fullpath, len(l:currentPath)-1,1) ==# '/'
                     let l:currentLine = substitute(l:currentLine, '/ *$', '', '')
                     call add(pathcomponents, l:currentLine)
                     let curPathComponent = curPathComponent + 1
 
-                    if fullpath ==# curPath
+                    if fullpath ==# l:currentPath
                         return l:lineNumber
                     endif
                 endif

--- a/lib/nerdtree/ui.vim
+++ b/lib/nerdtree/ui.vim
@@ -218,8 +218,8 @@ function! s:UI.getLineNum(file_node)
             let l:currentLine = self._stripMarkup(l:currentLine)
             let l:currentPath =  join(pathcomponents, '/') . '/' . l:currentLine
 
-            " NOTE: If the current path "starts with" the full path, then the
-            " paths are equal or we have a cascade that has the full path.
+            " If the current path "starts with" the full path, then the paths
+            " are equal or we have a cascade containing the full path.
             if stridx(l:currentPath, l:fullPath) == 0
                 return l:lineNumber
             endif

--- a/lib/nerdtree/ui.vim
+++ b/lib/nerdtree/ui.vim
@@ -203,9 +203,7 @@ function! s:UI.getLineNum(node)
         return self.getRootLineNum()
     endif
 
-    " the path components we have matched so far
     let l:pathComponents = [substitute(self.nerdtree.root.path.str({'format': 'UI'}), '/\s*$', '', '')]
-    " the index of the component we are searching for
     let l:currentPathComponent = 1
 
     let l:fullPath = a:node.path.str({'format': 'UI'})

--- a/lib/nerdtree/ui.vim
+++ b/lib/nerdtree/ui.vim
@@ -204,7 +204,7 @@ function! s:UI.getLineNum(file_node)
     endif
 
     " the path components we have matched so far
-    let pathcomponents = [substitute(self.nerdtree.root.path.str({'format': 'UI'}), '/ *$', '', '')]
+    let pathcomponents = [substitute(self.nerdtree.root.path.str({'format': 'UI'}), '/\s*$', '', '')]
     " the index of the component we are searching for
     let curPathComponent = 1
 

--- a/lib/nerdtree/ui.vim
+++ b/lib/nerdtree/ui.vim
@@ -212,9 +212,9 @@ function! s:UI.getLineNum(file_node)
 
     for l:lineNumber in range(self.getRootLineNum(), line('$'))
         let l:currentLine = getline(l:lineNumber)
-        let indent = self._indentLevelFor(l:currentLine)
+        let l:indentLevel = self._indentLevelFor(l:currentLine)
 
-        if indent ==# curPathComponent
+        if l:indentLevel ==# curPathComponent
             let l:currentLine = self._stripMarkup(l:currentLine)
             let l:currentPath =  join(pathcomponents, '/') . '/' . l:currentLine
 


### PR DESCRIPTION
Fixes #529.

This was complicated as it involved refactoring a fairly complex function.   This function has now been rewritten, and the style and logic are much cleaner, IMHO.

It's a very fundamental feature of the NERDTree that is used all over the place.  So, we shouldn't treat this change without care.  I suggest we use this for a while so that we can confirm that it works.

Let me know what you think.  Each commit is very specific, so you can see what I did at each step.
