### PR TITLE
Use a better arg for FINDSTR when using the m,l command in Windows.

### DIFF
--- a/nerdtree_plugin/fs_menu.vim
+++ b/nerdtree_plugin/fs_menu.vim
@@ -226,9 +226,9 @@ function! NERDTreeListNode()
     let treenode = g:NERDTreeFileNode.GetSelected()
     if !empty(treenode)
         let s:uname = system("uname")
-        let stat_cmd = 'stat -c "%s" ' 
-        
-        if s:uname =~? "Darwin"                
+        let stat_cmd = 'stat -c "%s" '
+
+        if s:uname =~? "Darwin"
             let stat_cmd = 'stat -f "%z" '
         endif
 

--- a/nerdtree_plugin/fs_menu.vim
+++ b/nerdtree_plugin/fs_menu.vim
@@ -248,32 +248,14 @@ function! NERDTreeListNodeWin32()
     let l:node = g:NERDTreeFileNode.GetSelected()
 
     if !empty(l:node)
-
-        let l:save_shell = &shell
-        set shell&
-
-        if exists('+shellslash')
-            let l:save_shellslash = &shellslash
-            set noshellslash
-        endif
-
-        let l:command = 'DIR /Q '
-                    \ . shellescape(l:node.path.str())
-                    \ . ' | FINDSTR /i "' . fnamemodify(l:node.path.str(), ':t') . '"'
-        let l:metadata = split(system(l:command), "\n")
-
-        if v:shell_error == 0
-            call nerdtree#echo(l:metadata[0])
-        else
-            call nerdtree#echoError('shell command failed')
-        endif
-
-        let &shell = l:save_shell
-
-        if exists('l:save_shellslash')
-            let &shellslash = l:save_shellslash
-        endif
-
+        let l:path = l:node.path.str()
+        let l:file_name = fnamemodify(l:path, ':t')
+        call nerdtree#echo(printf("%s  %s  %d  %s  %s",
+                    \ strftime("%c", getftime(l:path)),
+                    \ getftype(l:path),
+                    \ getfsize(l:path),
+                    \ getfperm(l:path),
+                    \ l:file_name))
         return
     endif
 

--- a/nerdtree_plugin/fs_menu.vim
+++ b/nerdtree_plugin/fs_menu.vim
@@ -250,12 +250,12 @@ function! NERDTreeListNodeWin32()
     if !empty(l:node)
         let l:path = l:node.path.str()
         let l:file_name = fnamemodify(l:path, ':t')
-        call nerdtree#echo(printf("%s  %s  %d  %s  %s",
+        call nerdtree#echo(printf("%s:%s  MOD:%s  BYTES:%d  PERMISSIONS:%s",
+                    \ toupper(getftype(l:path)),
+                    \ l:file_name,
                     \ strftime("%c", getftime(l:path)),
-                    \ getftype(l:path),
                     \ getfsize(l:path),
-                    \ getfperm(l:path),
-                    \ l:file_name))
+                    \ getfperm(l:path)))
         return
     endif
 

--- a/nerdtree_plugin/fs_menu.vim
+++ b/nerdtree_plugin/fs_menu.vim
@@ -259,8 +259,7 @@ function! NERDTreeListNodeWin32()
 
         let l:command = 'DIR /Q '
                     \ . shellescape(l:node.path.str())
-                    \ . ' | FINDSTR "^[012][0-9]/[0-3][0-9]/[12][0-9][0-9][0-9]"'
-
+                    \ . ' | FINDSTR /i "' . fnamemodify(l:node.path.str(), ':t') . '"'
         let l:metadata = split(system(l:command), "\n")
 
         if v:shell_error == 0


### PR DESCRIPTION
Fixes #883.

The only reason for the `FINDSTR` is to remove the extra seven lines of boilerplate that the `DIR` command thinks you need to know. Instead of "grepping" for the date (in its many different formats), we can more easily look for the filename itself.