### PR TITLE
Catch all errors, not just NERDTree errors.

### DIFF
--- a/lib/nerdtree/tree_file_node.vim
+++ b/lib/nerdtree/tree_file_node.vim
@@ -180,7 +180,7 @@ function! s:TreeFileNode.GetSelected()
         endif
 
         return b:NERDTree.root.findNode(l:path)
-    catch /^NERDTree/
+    catch
         return {}
     endtry
 endfunction


### PR DESCRIPTION
Fixes #893 

When middle-clicking, the s:TreeFileNode.GetSelected() function is
called along the way. If this is done outside of the NERDTree window,
there is no "b:NERDTree" variable, and the "E121: Undefined variable"
exception is thrown. This function was trying to catch only the NERDTree
specific errors; thus, it let the Undefined variable exception slip by.
This commit forces the function to catch all errors.