### PR TITLE
Call Resolve on the file's path when calling :NERDTreeFind.

### DIFF
--- a/autoload/nerdtree/ui_glue.vim
+++ b/autoload/nerdtree/ui_glue.vim
@@ -255,6 +255,7 @@ function! s:findAndRevealPath(pathStr)
     endif
 
     try
+        let l:pathStr = g:NERDTreePath.Resolve(l:pathStr)
         let l:pathObj = g:NERDTreePath.New(l:pathStr)
     catch /^NERDTree.InvalidArgumentsError/
         call nerdtree#echoWarning('invalid path')


### PR DESCRIPTION
Fixes #884.

When :NERDTreeFind creates a tree, it resolves the file's path, and
makes that its root. See :h resolve() for more info; it basically
tracks down links to their ultimate source. Then :NERDTreeFind
tries to find the file under that root, so it can be revealed. The
problem is that it compares the file's unresolved path against the
resolved path in the root. Here is the scenario:

/tmp/ is a link to /private/tmp/
:e /tmp/foo will open the file as expected
:NERDTreeFind will first create a tree with a root of /private/tmp/
Then it tries to find /tmp/foo, but it can't, because the path
names don't match.

This commit resolves /tmp/foo to the actual location of
/private/tmp/foo; thus, it is able to find the file in the tree.