### PR TITLE
Force sort to recalculate the cached sortKey.

### DIFF
--- a/nerdtree_plugin/fs_menu.vim
+++ b/nerdtree_plugin/fs_menu.vim
@@ -128,6 +128,8 @@ function! NERDTreeAddNode()
         let parentNode = b:NERDTree.root.findNode(newPath.getParent())
 
         let newTreeNode = g:NERDTreeFileNode.New(newPath, b:NERDTree)
+        " Emptying g:NERDTreeOldSortOrder forces the sort to
+        " recalculate the cached sortKey so nodes sort correctly.
         let g:NERDTreeOldSortOrder = []
         if empty(parentNode)
             call b:NERDTree.root.refresh()
@@ -159,6 +161,8 @@ function! NERDTreeMoveNode()
         let bufnum = bufnr("^".curNode.path.str()."$")
 
         call curNode.rename(newNodePath)
+        " Emptying g:NERDTreeOldSortOrder forces the sort to
+        " recalculate the cached sortKey so nodes sort correctly.
         let g:NERDTreeOldSortOrder = []
         call b:NERDTree.root.refresh()
         call NERDTreeRender()
@@ -285,6 +289,8 @@ function! NERDTreeCopyNode()
         if confirmed
             try
                 let newNode = currentNode.copy(newNodePath)
+                " Emptying g:NERDTreeOldSortOrder forces the sort to
+                " recalculate the cached sortKey so nodes sort correctly.
                 let g:NERDTreeOldSortOrder = []
                 if empty(newNode)
                     call b:NERDTree.root.refresh()

--- a/nerdtree_plugin/fs_menu.vim
+++ b/nerdtree_plugin/fs_menu.vim
@@ -128,6 +128,7 @@ function! NERDTreeAddNode()
         let parentNode = b:NERDTree.root.findNode(newPath.getParent())
 
         let newTreeNode = g:NERDTreeFileNode.New(newPath, b:NERDTree)
+        let g:NERDTreeOldSortOrder = []
         if empty(parentNode)
             call b:NERDTree.root.refresh()
             call b:NERDTree.render()
@@ -158,6 +159,7 @@ function! NERDTreeMoveNode()
         let bufnum = bufnr("^".curNode.path.str()."$")
 
         call curNode.rename(newNodePath)
+        let g:NERDTreeOldSortOrder = []
         call b:NERDTree.root.refresh()
         call NERDTreeRender()
 
@@ -283,6 +285,7 @@ function! NERDTreeCopyNode()
         if confirmed
             try
                 let newNode = currentNode.copy(newNodePath)
+                let g:NERDTreeOldSortOrder = []
                 if empty(newNode)
                     call b:NERDTree.root.refresh()
                     call b:NERDTree.render()


### PR DESCRIPTION
Fixes #880.

The problem in issue #880 was caused by the sort using the old sortKey.
For example, given nodes A, B, and C, if B were renamed to D, the sort
was still using B as its sortKey, thus not moving it.

It's a bit of a hack, but if we set g:NERDTreeOldSortOrder to an empty
list, the cached sortKey will be recalculated. I did the same thing for
both the Copy and Add functions as well.