### PR TITLE
Parse . and .. from path string with trailing slash.

### DIFF
--- a/lib/nerdtree/tree_dir_node.vim
+++ b/lib/nerdtree/tree_dir_node.vim
@@ -304,9 +304,11 @@ function! s:TreeDirNode._glob(pattern, all)
         for l:file in l:globList
             let l:tail = fnamemodify(l:file, ':t')
 
-            " Double the modifier if only a separator was stripped.
+            " If l:file has a trailing slash, then its :tail will be ''. Use
+            " :h to drop the slash and the empty string after it; then use :t
+            " to get the directory name.
             if l:tail == ''
-                let l:tail = fnamemodify(l:file, ':t:t')
+                let l:tail = fnamemodify(l:file, ':h:t')
             endif
 
             if l:tail == '.' || l:tail == '..'


### PR DESCRIPTION
Fixes #555.

I cherry-picked this commit from #868, because that PR addresses different issues than what's described in #555. See [this comment](https://github.com/scrooloose/nerdtree/issues/555#issuecomment-414332849) for technical details. It boils down to how the `glob()` function returns values when braces are present in the pattern vs. when they're not.