### PR TITLE
Fix vsplit to not open empty buffer

### DIFF
--- a/lib/nerdtree/opener.vim
+++ b/lib/nerdtree/opener.vim
@@ -220,7 +220,7 @@ function! s:Opener._newVSplit()
     endif
 
     call nerdtree#exec('wincmd p')
-    vnew
+    vsplit
 
     let l:currentWindowNumber = winnr()
 


### PR DESCRIPTION
Fixes #616.

Steps to reproduce bug:
1. Open a file from nerdtree
2. Delete buffer with :bd
3. Reopen same file from nerdtree with vsplit (s).

This reopens the buffer that didn't unload from memory with :bd and creates a new empty buffer with [No name].