### PR TITLE
Allow highlighting more than one flag.

### DIFF
--- a/syntax/nerdtree.vim
+++ b/syntax/nerdtree.vim
@@ -33,8 +33,8 @@ exec 'syn match NERDTreeFile  #^[^"\.'.s:dirArrows.'] *[^'.s:dirArrows.']*# cont
 "highlighting for readonly files
 exec 'syn match NERDTreeRO # *\zs.*\ze \['.g:NERDTreeGlyphReadOnly.'\]# contains=NERDTreeIgnore,NERDTreeBookmark,NERDTreeFile'
 
-syn match NERDTreeFlags #^ *\zs\[.\]# containedin=NERDTreeFile,NERDTreeExecFile
-syn match NERDTreeFlags #\[.\]# containedin=NERDTreeDir
+syn match NERDTreeFlags #^ *\zs\[[^\]]*\]# containedin=NERDTreeFile,NERDTreeExecFile
+syn match NERDTreeFlags #\[[^\]]*\]# containedin=NERDTreeDir
 
 "highlighing to conceal the delimiter around the file/dir name
 if has("conceal")


### PR DESCRIPTION
If there's more than one flag on a node, there's no way to highlight them separately by adding some custom syntax. This should fix it.