### PR TITLE
Add two more disqualifications for isCascadable().

### DIFF
--- a/lib/nerdtree/tree_dir_node.vim
+++ b/lib/nerdtree/tree_dir_node.vim
@@ -376,6 +376,16 @@ function! s:TreeDirNode.isCascadable()
         return 0
     endif
 
+    if self.path.isSymLink
+        return 0
+    endif
+
+    for i in g:NERDTreeBookmark.Bookmarks()
+        if i.path.equals(self.path)
+            return 0
+        endif
+    endfor
+
     let c = self.getVisibleChildren()
     return len(c) == 1 && c[0].path.isDirectory
 endfunction

--- a/lib/nerdtree/tree_dir_node.vim
+++ b/lib/nerdtree/tree_dir_node.vim
@@ -370,7 +370,11 @@ function! s:TreeDirNode.hasVisibleChildren()
 endfunction
 
 " FUNCTION: TreeDirNode.isCascadable() {{{1
-" true if this dir has only one visible child - which is also a dir
+" true if this dir has only one visible child that is also a dir
+" false if this dir is bookmarked or symlinked. Why? Two reasons:
+"  1. If cascaded, we don't know which dir is bookmarked or is a symlink.
+"  2. If the parent is a symlink or is bookmarked, you end up with unparsable
+"     text, and NERDTree cannot get the path of any child node.
 function! s:TreeDirNode.isCascadable()
     if g:NERDTreeCascadeSingleChildDir == 0
         return 0


### PR DESCRIPTION
Fixes #749.

A directory that is bookmarked or that is a symlink to another location
has trailing text indicating so. This extra text causes problem when
cascading with a directory underneath it, so disable it in this case.