### PR TITLE
Document NERDTreeNodeDelimiter #912

### DIFF
--- a/doc/NERDTree.txt
+++ b/doc/NERDTree.txt
@@ -2,17 +2,17 @@
 
 
 
-    omg its ... ~
-
-    ________  ________   _   ____________  ____     __________  ____________~
-   /_  __/ / / / ____/  / | / / ____/ __ \/ __ \   /_  __/ __ \/ ____/ ____/~
-    / / / /_/ / __/    /  |/ / __/ / /_/ / / / /    / / / /_/ / __/ / __/   ~
-   / / / __  / /___   / /|  / /___/ _, _/ /_/ /    / / / _, _/ /___/ /___   ~
-  /_/ /_/ /_/_____/  /_/ |_/_____/_/ |_/_____/    /_/ /_/ |_/_____/_____/   ~
+   Are you ready for this? It's the...
 
 
-                              Reference Manual~
 
+   Y88b Y88 888'Y88 888 88e  888 88e   88P'888'Y88                           ~
+    Y88b Y8 888 ,'Y 888 888D 888 888b  P'  888  'Y 888,8,  ,e e,   ,e e,     ~
+   b Y88b Y 888C8   888 88"  888 8888D     888     888 "  d88 88b d88 88b    ~
+   8b Y88b  888 ",d 888 b,   888 888P      888     888    888   , 888   ,    ~
+   88b Y88b 888,d88 888 88b, 888 88"       888     888     "YeeP"  "YeeP"    ~
+                                                                             ~
+                              Reference Manual                               ~
 
 
 
@@ -1351,6 +1351,11 @@ issues is, as you may have guessed, to go to
 The latest stable and development versions are on Github.
     Stable: http://github.com/scrooloose/nerdtree
     Development: http://github.com/scrooloose/nerdtree/branches
+
+Title Credit:
+    Patrick Gillespie's Text ASCII Art Generator
+    http://patorjk.com/software/taag
+    http://patorjk.com/software/taag/#p=display&f=Rozzo&t=NERDTree
 
 ==============================================================================
 6. License                                                   *NERDTreeLicense*

--- a/doc/NERDTree.txt
+++ b/doc/NERDTree.txt
@@ -1348,8 +1348,9 @@ receive your emails, the best way to submit suggestions and to report issues
 is, as you may have guessed, to go to
     http://github.com/scrooloose/nerdtree/issues.
 
-The latest stable and develpment versions are on Github.
-    http://github.com/scrooloose/nerdtree
+The latest stable and development versions are on Github.
+    Stable: http://github.com/scrooloose/nerdtree
+    Development: http://github.com/scrooloose/nerdtree/branches
 
 ==============================================================================
 6. License                                                   *NERDTreeLicense*

--- a/doc/NERDTree.txt
+++ b/doc/NERDTree.txt
@@ -17,7 +17,7 @@
 
 
 ==============================================================================
-CONTENTS                                                   *NERDTree-contents*
+CONTENTS                                                     *NERDTree-contents*
 
     1.Intro...................................|NERDTree|
     2.Functionality provided..................|NERDTreeFunctionality|
@@ -40,7 +40,7 @@ CONTENTS                                                   *NERDTree-contents*
     6.License.................................|NERDTreeLicense|
 
 ==============================================================================
-1. Intro                                                            *NERDTree*
+1. Intro                                                              *NERDTree*
 
 What is this "NERD tree"??
 
@@ -94,12 +94,12 @@ The following features and functionality are provided by the NERD tree:
 
 
 ==============================================================================
-2. Functionality provided                              *NERDTreeFunctionality*
+2. Functionality provided                                *NERDTreeFunctionality*
 
 ------------------------------------------------------------------------------
-2.1. Global Commands                                  *NERDTreeGlobalCommands*
+2.1. Global Commands                                    *NERDTreeGlobalCommands*
 
-:NERDTree [<start-directory> | <bookmark>]                         *:NERDTree*
+:NERDTree [<start-directory> | <bookmark>]                           *:NERDTree*
     Opens a fresh NERD tree. The root of the tree depends on the argument
     given. There are 3 cases: If no argument is given, the current directory
     will be used.  If a directory is given, that will be used. If a bookmark
@@ -107,21 +107,21 @@ The following features and functionality are provided by the NERD tree:
         :NERDTree /home/marty/vim7/src
         :NERDTree foo   (foo is the name of a bookmark)
 <
-:NERDTreeFromBookmark <bookmark>                       *:NERDTreeFromBookmark*
+:NERDTreeFromBookmark <bookmark>                         *:NERDTreeFromBookmark*
     Opens a fresh NERD tree with the root initialized to the dir for
     <bookmark>.  The only reason to use this command over :NERDTree is for
     the completion (which is for bookmarks rather than directories).
 
-:NERDTreeToggle [<start-directory> | <bookmark>]             *:NERDTreeToggle*
+:NERDTreeToggle [<start-directory> | <bookmark>]               *:NERDTreeToggle*
     If a NERD tree already exists for this tab, it is reopened and rendered
     again.  If no NERD tree exists for this tab then this command acts the
     same as the |:NERDTree| command.
 
-:NERDTreeFocus                                                *:NERDTreeFocus*
+:NERDTreeFocus                                                  *:NERDTreeFocus*
     Opens (or reopens) the NERD Tree if it is not currently visible;
     otherwise, the cursor is moved to the already-open NERD Tree.
 
-:NERDTreeMirror                                              *:NERDTreeMirror*
+:NERDTreeMirror                                                *:NERDTreeMirror*
     Shares an existing NERD tree, from another tab, in the current tab.
     Changes made to one tree are reflected in both as they are actually the
     same buffer.
@@ -129,10 +129,10 @@ The following features and functionality are provided by the NERD tree:
     If only one other NERD tree exists, that tree is automatically mirrored.
     If more than one exists, the script will ask which tree to mirror.
 
-:NERDTreeClose                                                *:NERDTreeClose*
+:NERDTreeClose                                                  *:NERDTreeClose*
     Close the NERD tree in this tab.
 
-:NERDTreeFind [<path>]                                         *:NERDTreeFind*
+:NERDTreeFind [<path>]                                           *:NERDTreeFind*
     Without the optional argument, find and reveal the file for the active
     buffer in the NERDTree window.  With the <path> argument, find and
     reveal the specified path.
@@ -141,21 +141,21 @@ The following features and functionality are provided by the NERD tree:
     placed on the tree node for the determined path.  If a NERDTree for the
     current tab does not exist, a new one will be initialized.
 
-:NERDTreeCWD                                                    *:NERDTreeCWD*
+:NERDTreeCWD                                                      *:NERDTreeCWD*
     Change the NERDTree root to the current working directory.  If no
     NERDTree exists for this tab, a new one is opened.
 
-:NERDTreeRefreshRoot                                    *:NERDTreeRefreshRoot*
+:NERDTreeRefreshRoot                                      *:NERDTreeRefreshRoot*
     Refreshes the NERD tree root node.
 
 ------------------------------------------------------------------------------
-2.2. Bookmarks                                             *NERDTreeBookmarks*
+2.2. Bookmarks                                               *NERDTreeBookmarks*
 
 Bookmarks in the NERD tree are a way to tag files or directories of interest.
 For example, you could use bookmarks to tag all of your project directories.
 
 ------------------------------------------------------------------------------
-2.2.1. The Bookmark Table                              *NERDTreeBookmarkTable*
+2.2.1. The Bookmark Table                                *NERDTreeBookmarkTable*
 
 If the bookmark table is active (see |NERDTree-B| and
 |NERDTreeShowBookmarks|), it will be rendered above the tree. You can double
@@ -163,7 +163,7 @@ click bookmarks or use the |NERDTree-o| mapping to activate them. See also,
 |NERDTree-t| and |NERDTree-T|
 
 ------------------------------------------------------------------------------
-2.2.2. Bookmark commands                            *NERDTreeBookmarkCommands*
+2.2.2. Bookmark commands                              *NERDTreeBookmarkCommands*
 
 Note: The following commands are only available within the NERDTree buffer.
 
@@ -204,7 +204,7 @@ Note: The following commands are only available within the NERDTree buffer.
 See also |:NERDTree| and |:NERDTreeFromBookmark|.
 
 ------------------------------------------------------------------------------
-2.2.3. Invalid Bookmarks                            *NERDTreeInvalidBookmarks*
+2.2.3. Invalid Bookmarks                              *NERDTreeInvalidBookmarks*
 
 If invalid bookmarks are detected, the script will issue an error message and
 the invalid bookmarks will become unavailable for use.
@@ -220,58 +220,57 @@ After you have corrected any invalid bookmarks, either restart vim, or go
 :ReadBookmarks from the NERD tree window.
 
 ------------------------------------------------------------------------------
-2.3. NERD tree Mappings                                     *NERDTreeMappings*
+2.3. NERD tree Mappings                                       *NERDTreeMappings*
 
-Default  Description~                                             help-tag~
-Key~
+Default~
+Key      Description                                                  help-tag~
 
-o.......Open files, directories and bookmarks....................|NERDTree-o|
-go......Open selected file, but leave cursor in the NERDTree.....|NERDTree-go|
-t.......Open selected node/bookmark in a new tab.................|NERDTree-t|
-T.......Same as 't' but keep the focus on the current tab........|NERDTree-T|
-i.......Open selected file in a split window.....................|NERDTree-i|
-gi......Same as i, but leave the cursor on the NERDTree..........|NERDTree-gi|
-s.......Open selected file in a new vsplit.......................|NERDTree-s|
-gs......Same as s, but leave the cursor on the NERDTree..........|NERDTree-gs|
-O.......Recursively open the selected directory..................|NERDTree-O|
-x.......Close the current nodes parent...........................|NERDTree-x|
-X.......Recursively close all children of the current node.......|NERDTree-X|
-e.......Edit the current dir.....................................|NERDTree-e|
+o........Open files, directories and bookmarks......................|NERDTree-o|
+go.......Open selected file, but leave cursor in the NERDTree......|NERDTree-go|
+t........Open selected node/bookmark in a new tab...................|NERDTree-t|
+T........Same as 't' but keep the focus on the current tab..........|NERDTree-T|
+i........Open selected file in a split window.......................|NERDTree-i|
+gi.......Same as i, but leave the cursor on the NERDTree...........|NERDTree-gi|
+s........Open selected file in a new vsplit.........................|NERDTree-s|
+gs.......Same as s, but leave the cursor on the NERDTree...........|NERDTree-gs|
+O........Recursively open the selected directory....................|NERDTree-O|
+x........Close the current nodes parent.............................|NERDTree-x|
+X........Recursively close all children of the current node.........|NERDTree-X|
+e........Edit the current dir.......................................|NERDTree-e|
 
-<CR>...............same as |NERDTree-o|.
-double-click.......same as the |NERDTree-o| map.
-middle-click.......same as |NERDTree-i| for files, same as
-                   |NERDTree-e| for dirs.
+<CR>............same as |NERDTree-o|.
+double-click....same as |NERDTree-o|.
+middle-click....same as |NERDTree-i| for files, and |NERDTree-e| for dirs.
 
-D.......Delete the current bookmark .............................|NERDTree-D|
+D........Delete the current bookmark ...............................|NERDTree-D|
 
-P.......Jump to the root node....................................|NERDTree-P|
-p.......Jump to current nodes parent.............................|NERDTree-p|
-K.......Jump up inside directories at the current tree depth.....|NERDTree-K|
-J.......Jump down inside directories at the current tree depth...|NERDTree-J|
-<C-J>...Jump down to the next sibling of the current directory...|NERDTree-C-J|
-<C-K>...Jump up to the previous sibling of the current directory.|NERDTree-C-K|
+P........Jump to the root node......................................|NERDTree-P|
+p........Jump to current nodes parent...............................|NERDTree-p|
+K........Jump up inside directories at the current tree depth.......|NERDTree-K|
+J........Jump down inside directories at the current tree depth.....|NERDTree-J|
+<C-J>....Jump down to next sibling of the current directory.......|NERDTree-C-J|
+<C-K>....Jump up to previous sibling of the current directory.....|NERDTree-C-K|
 
-C.......Change the tree root to the selected dir.................|NERDTree-C|
-u.......Move the tree root up one directory......................|NERDTree-u|
-U.......Same as 'u' except the old root node is left open........|NERDTree-U|
-r.......Recursively refresh the current directory................|NERDTree-r|
-R.......Recursively refresh the current root.....................|NERDTree-R|
-m.......Display the NERD tree menu...............................|NERDTree-m|
-cd......Change the CWD to the dir of the selected node...........|NERDTree-cd|
-CD......Change tree root to the CWD..............................|NERDTree-CD|
+C........Change the tree root to the selected dir...................|NERDTree-C|
+u........Move the tree root up one directory........................|NERDTree-u|
+U........Same as 'u' except the old root node is left open..........|NERDTree-U|
+r........Recursively refresh the current directory..................|NERDTree-r|
+R........Recursively refresh the current root.......................|NERDTree-R|
+m........Display the NERD tree menu.................................|NERDTree-m|
+cd.......Change the CWD to the dir of the selected node............|NERDTree-cd|
+CD.......Change tree root to the CWD...............................|NERDTree-CD|
 
-I.......Toggle whether hidden files displayed....................|NERDTree-I|
-f.......Toggle whether the file filters are used.................|NERDTree-f|
-F.......Toggle whether files are displayed.......................|NERDTree-F|
-B.......Toggle whether the bookmark table is displayed...........|NERDTree-B|
+I........Toggle whether hidden files displayed......................|NERDTree-I|
+f........Toggle whether the file filters are used...................|NERDTree-f|
+F........Toggle whether files are displayed.........................|NERDTree-F|
+B........Toggle whether the bookmark table is displayed.............|NERDTree-B|
 
-q.......Close the NERDTree window................................|NERDTree-q|
-A.......Zoom (maximize/minimize) the NERDTree window.............|NERDTree-A|
-?.......Toggle the display of the quick help.....................|NERDTree-?|
+q........Close the NERDTree window..................................|NERDTree-q|
+A........Zoom (maximize/minimize) the NERDTree window...............|NERDTree-A|
+?........Toggle the display of the quick help.......................|NERDTree-?|
 
 ------------------------------------------------------------------------------
-                                                                  *NERDTree-o*
+                                                                    *NERDTree-o*
 Default key: o
 Map setting: NERDTreeMapActivateNode
 Applies to: files and directories.
@@ -288,7 +287,7 @@ If a bookmark that links to a file is selected then that file is opened in the
 previous window.
 
 ------------------------------------------------------------------------------
-                                                                 *NERDTree-go*
+                                                                   *NERDTree-go*
 Default key: go
 Map setting: NERDTreeMapPreview
 Applies to: files.
@@ -300,7 +299,7 @@ The default key combo for this mapping is "g" + NERDTreeMapActivateNode (see
 |NERDTree-o|).
 
 ------------------------------------------------------------------------------
-                                                                  *NERDTree-t*
+                                                                    *NERDTree-t*
 Default key: t
 Map setting: NERDTreeMapOpenInTab
 Applies to: files and directories.
@@ -313,7 +312,7 @@ that directory in a new tab. If the bookmark points to a file, open that file
 in a new tab.
 
 ------------------------------------------------------------------------------
-                                                                  *NERDTree-T*
+                                                                    *NERDTree-T*
 Default key: T
 Map setting: NERDTreeMapOpenInTabSilent
 Applies to: files and directories.
@@ -321,7 +320,7 @@ Applies to: files and directories.
 The same as |NERDTree-t| except that the focus is kept in the current tab.
 
 ------------------------------------------------------------------------------
-                                                                  *NERDTree-i*
+                                                                    *NERDTree-i*
 Default key: i
 Map setting: NERDTreeMapOpenSplit
 Applies to: files.
@@ -330,7 +329,7 @@ Opens the selected file in a new split window and puts the cursor in the new
 window.
 
 ------------------------------------------------------------------------------
-                                                                 *NERDTree-gi*
+                                                                   *NERDTree-gi*
 Default key: gi
 Map setting: NERDTreeMapPreviewSplit
 Applies to: files.
@@ -341,7 +340,7 @@ The default key combo for this mapping is "g" + NERDTreeMapOpenSplit (see
 |NERDTree-i|).
 
 ------------------------------------------------------------------------------
-                                                                  *NERDTree-s*
+                                                                    *NERDTree-s*
 Default key: s
 Map setting: NERDTreeMapOpenVSplit
 Applies to: files.
@@ -350,7 +349,7 @@ Opens the selected file in a new vertically split window and puts the cursor
 in the new window.
 
 ------------------------------------------------------------------------------
-                                                                 *NERDTree-gs*
+                                                                   *NERDTree-gs*
 Default key: gs
 Map setting: NERDTreeMapPreviewVSplit
 Applies to: files.
@@ -361,7 +360,7 @@ The default key combo for this mapping is "g" + NERDTreeMapOpenVSplit (see
 |NERDTree-s|).
 
 ------------------------------------------------------------------------------
-                                                                  *NERDTree-O*
+                                                                    *NERDTree-O*
 Default key: O
 Map setting: NERDTreeMapOpenRecursively
 Applies to: directories.
@@ -374,7 +373,7 @@ hidden file filter (see |NERDTreeShowHidden|) then its contents are not
 cached. This is handy, especially if you have .svn directories.
 
 ------------------------------------------------------------------------------
-                                                                  *NERDTree-x*
+                                                                    *NERDTree-x*
 Default key: x
 Map setting: NERDTreeMapCloseDir
 Applies to: files and directories.
@@ -382,7 +381,7 @@ Applies to: files and directories.
 Closes the parent of the selected node.
 
 ------------------------------------------------------------------------------
-                                                                  *NERDTree-X*
+                                                                    *NERDTree-X*
 Default key: X
 Map setting: NERDTreeMapCloseChildren
 Applies to: directories.
@@ -392,7 +391,7 @@ Recursively closes all children of the selected directory.
 Tip: To quickly "reset" the tree, use |NERDTree-P| with this mapping.
 
 ------------------------------------------------------------------------------
-                                                                  *NERDTree-e*
+                                                                    *NERDTree-e*
 Default key: e
 Map setting: NERDTreeMapOpenExpl
 Applies to: files and directories.
@@ -402,7 +401,7 @@ result in a NERD tree or a netrw being opened, depending on
 |NERDTreeHijackNetrw|.
 
 ------------------------------------------------------------------------------
-                                                                  *NERDTree-D*
+                                                                    *NERDTree-D*
 Default key: D
 Map setting: NERDTreeMapDeleteBookmark
 Applies to: lines in the bookmarks table
@@ -410,7 +409,7 @@ Applies to: lines in the bookmarks table
 Deletes the currently selected bookmark.
 
 ------------------------------------------------------------------------------
-                                                                  *NERDTree-P*
+                                                                    *NERDTree-P*
 Default key: P
 Map setting: NERDTreeMapJumpRoot
 Applies to: no restrictions.
@@ -418,7 +417,7 @@ Applies to: no restrictions.
 Jump to the tree root.
 
 ------------------------------------------------------------------------------
-                                                                  *NERDTree-p*
+                                                                    *NERDTree-p*
 Default key: p
 Map setting: NERDTreeMapJumpParent
 Applies to: files and directories.
@@ -426,7 +425,7 @@ Applies to: files and directories.
 Jump to the parent node of the selected node.
 
 ------------------------------------------------------------------------------
-                                                                  *NERDTree-K*
+                                                                    *NERDTree-K*
 Default key: K
 Map setting: NERDTreeMapJumpFirstChild
 Applies to: files and directories.
@@ -439,7 +438,7 @@ If the cursor is already on the first node then do the following:
     * go to the first child of that node
 
 ------------------------------------------------------------------------------
-                                                                  *NERDTree-J*
+                                                                    *NERDTree-J*
 Default key: J
 Map setting: NERDTreeMapJumpLastChild
 Applies to: files and directories.
@@ -452,7 +451,7 @@ If the cursor is already on the last node then do the following:
     * go to the last child of that node
 
 ------------------------------------------------------------------------------
-                                                                *NERDTree-C-J*
+                                                                  *NERDTree-C-J*
 Default key: <C-J>
 Map setting: NERDTreeMapJumpNextSibling
 Applies to: files and directories.
@@ -460,7 +459,7 @@ Applies to: files and directories.
 Jump to the next sibling of the selected node.
 
 ------------------------------------------------------------------------------
-                                                                *NERDTree-C-K*
+                                                                  *NERDTree-C-K*
 Default key: <C-K>
 Map setting: NERDTreeMapJumpPrevSibling
 Applies to: files and directories.
@@ -468,7 +467,7 @@ Applies to: files and directories.
 Jump to the previous sibling of the selected node.
 
 ------------------------------------------------------------------------------
-                                                                  *NERDTree-C*
+                                                                    *NERDTree-C*
 Default key: C
 Map setting: NERDTreeMapChangeRoot
 Applies to: files and directories.
@@ -477,7 +476,7 @@ Make the selected directory node the new tree root. If a file is selected, its
 parent is used.
 
 ------------------------------------------------------------------------------
-                                                                  *NERDTree-u*
+                                                                    *NERDTree-u*
 Default key: u
 Map setting: NERDTreeMapUpdir
 Applies to: no restrictions.
@@ -485,7 +484,7 @@ Applies to: no restrictions.
 Move the tree root up a dir (like doing a "cd ..").
 
 ------------------------------------------------------------------------------
-                                                                  *NERDTree-U*
+                                                                    *NERDTree-U*
 Default key: U
 Map setting: NERDTreeMapUpdirKeepOpen
 Applies to: no restrictions.
@@ -493,7 +492,7 @@ Applies to: no restrictions.
 Like |NERDTree-u| except that the old tree root is kept open.
 
 ------------------------------------------------------------------------------
-                                                                  *NERDTree-r*
+                                                                    *NERDTree-r*
 Default key: r
 Map setting: NERDTreeMapRefresh
 Applies to: files and directories.
@@ -504,7 +503,7 @@ for changes and represent them in the tree.
 If a file node is selected then the above is done on it's parent.
 
 ------------------------------------------------------------------------------
-                                                                  *NERDTree-R*
+                                                                    *NERDTree-R*
 Default key: R
 Map setting: NERDTreeMapRefreshRoot
 Applies to: no restrictions.
@@ -512,7 +511,7 @@ Applies to: no restrictions.
 Recursively refresh the tree root.
 
 ------------------------------------------------------------------------------
-                                                                  *NERDTree-m*
+                                                                    *NERDTree-m*
 Default key: m
 Map setting: NERDTreeMapMenu
 Applies to: files and directories.
@@ -520,7 +519,7 @@ Applies to: files and directories.
 Display the NERD tree menu. See |NERDTreeMenu| for details.
 
 ------------------------------------------------------------------------------
-                                                                 *NERDTree-cd*
+                                                                   *NERDTree-cd*
 Default key: cd
 Map setting: NERDTreeMapChdir
 Applies to: files and directories.
@@ -528,7 +527,7 @@ Applies to: files and directories.
 Change Vim's current working directory to that of the selected node.
 
 ------------------------------------------------------------------------------
-                                                                 *NERDTree-CD*
+                                                                   *NERDTree-CD*
 Default key: CD
 Map setting: NERDTreeMapCWD
 Applies to: no restrictions.
@@ -536,7 +535,7 @@ Applies to: no restrictions.
 Change the NERDTree root to Vim's current working directory.
 
 ------------------------------------------------------------------------------
-                                                                  *NERDTree-I*
+                                                                    *NERDTree-I*
 Default key: I
 Map setting: NERDTreeMapToggleHidden
 Applies to: no restrictions.
@@ -544,7 +543,7 @@ Applies to: no restrictions.
 Toggles whether hidden files (i.e. "dot files") are displayed.
 
 ------------------------------------------------------------------------------
-                                                                  *NERDTree-f*
+                                                                    *NERDTree-f*
 Default key: f
 Map setting: NERDTreeMapToggleFilters
 Applies to: no restrictions.
@@ -552,7 +551,7 @@ Applies to: no restrictions.
 Toggles whether file filters are used. See |NERDTreeIgnore| for details.
 
 ------------------------------------------------------------------------------
-                                                                  *NERDTree-F*
+                                                                    *NERDTree-F*
 Default key: F
 Map setting: NERDTreeMapToggleFiles
 Applies to: no restrictions.
@@ -560,7 +559,7 @@ Applies to: no restrictions.
 Toggles whether file nodes are displayed.
 
 ------------------------------------------------------------------------------
-                                                                  *NERDTree-B*
+                                                                    *NERDTree-B*
 Default key: B
 Map setting: NERDTreeMapToggleBookmarks
 Applies to: no restrictions.
@@ -568,7 +567,7 @@ Applies to: no restrictions.
 Toggles whether the bookmarks table is displayed.
 
 ------------------------------------------------------------------------------
-                                                                  *NERDTree-q*
+                                                                    *NERDTree-q*
 Default key: q
 Map setting: NERDTreeMapQuit
 Applies to: no restrictions.
@@ -576,7 +575,7 @@ Applies to: no restrictions.
 Closes the NERDtree window.
 
 ------------------------------------------------------------------------------
-                                                                  *NERDTree-A*
+                                                                    *NERDTree-A*
 Default key: A
 Map setting: NERDTreeMapToggleZoom
 Applies to: no restrictions.
@@ -584,7 +583,7 @@ Applies to: no restrictions.
 Maximize (zoom) and minimize the NERDtree window.
 
 ------------------------------------------------------------------------------
-                                                                  *NERDTree-?*
+                                                                    *NERDTree-?*
 Default key: ?
 Map setting: NERDTreeMapHelp
 Applies to: no restrictions.
@@ -592,7 +591,7 @@ Applies to: no restrictions.
 Toggles whether the quickhelp is displayed.
 
 ------------------------------------------------------------------------------
-2.3. The NERD tree menu                                         *NERDTreeMenu*
+2.3. The NERD tree menu                                           *NERDTreeMenu*
 
 The NERD tree has a menu that can be programmed via the an API (see
 |NERDTreeMenuAPI|). The idea is to simulate the "right click" menus that most
@@ -606,11 +605,11 @@ menu item to execute executable files.
 Related tags: |NERDTree-m| |NERDTreeApi|
 
 ==============================================================================
-3. Customisation                                            *NERDTreeSettings*
+3. Customisation                                              *NERDTreeSettings*
 
 
 ------------------------------------------------------------------------------
-3.1. Customisation summary                           *NERDTreeSettingsSummary*
+3.1. Customisation summary                             *NERDTreeSettingsSummary*
 
 The plugin provides the following settings that can customise the behaviour
 the NERD tree. These settings should be set in your vimrc, using `:let`.
@@ -712,20 +711,20 @@ the NERD tree. These settings should be set in your vimrc, using `:let`.
                               characters on the line of text.
 
 ------------------------------------------------------------------------------
-3.2. Customisation details                           *NERDTreeSettingsDetails*
+3.2. Customisation details                             *NERDTreeSettingsDetails*
 
 To enable any of the below settings you should put an appropriate >
     let <setting>=<value>
 <line in your ~/.vimrc.
 
-                                                            *loaded_nerd_tree*
+                                                              *loaded_nerd_tree*
 If this plugin is making you feel homicidal, it may be a good idea to turn it
 off with this line in your vimrc: >
     let loaded_nerd_tree=1
 <
 
 ------------------------------------------------------------------------------
-                                                          *NERDTreeAutoCenter*
+                                                            *NERDTreeAutoCenter*
 Values: 0 or 1.
 Default: 1
 
@@ -739,7 +738,7 @@ i.e. |NERDTree-J| |NERDTree-K| |NERDTree-C-J| |NERDTree-C-K| |NERDTree-p|
 The centering is done with a |zz| operation.
 
 ------------------------------------------------------------------------------
-                                                 *NERDTreeAutoCenterThreshold*
+                                                   *NERDTreeAutoCenterThreshold*
 Values: Any natural number.
 Default: 3
 
@@ -747,7 +746,7 @@ This setting controls the "sensitivity" of the NERD tree auto centering. See
 |NERDTreeAutoCenter| for details.
 
 ------------------------------------------------------------------------------
-                                                   *NERDTreeCaseSensitiveSort*
+                                                     *NERDTreeCaseSensitiveSort*
 Values: 0 or 1.
 Default: 0.
 
@@ -768,7 +767,7 @@ into account. The above nodes would then be sorted like this: >
     boner.c
 <
 ------------------------------------------------------------------------------
-                                                         *NERDTreeNaturalSort*
+                                                           *NERDTreeNaturalSort*
 Values: 0 or 1.
 Default: 0.
 
@@ -795,7 +794,7 @@ above nodes would then be sorted like this: >
     z110.txt
 <
 ------------------------------------------------------------------------------
-                                                           *NERDTreeChDirMode*
+                                                             *NERDTreeChDirMode*
 
 Values: 0, 1 or 2.
 Default: 0.
@@ -818,7 +817,7 @@ is /home/marty/foobar and you make the node for /home/marty/foobar/baz the new
 root then the CWD will become /home/marty/foobar/baz.
 
 ------------------------------------------------------------------------------
-                                                 *NERDTreeHighlightCursorline*
+                                                   *NERDTreeHighlightCursorline*
 Values: 0 or 1.
 Default: 1.
 
@@ -826,7 +825,7 @@ If set to 1, the current cursor line in the NERD tree buffer will be
 highlighted. This is done using the `'cursorline'` Vim option.
 
 ------------------------------------------------------------------------------
-                                                         *NERDTreeHijackNetrw*
+                                                           *NERDTreeHijackNetrw*
 Values: 0 or 1.
 Default: 1.
 
@@ -842,7 +841,7 @@ following respects:
     2. you can have one tree per window - instead of per tab.
 
 ------------------------------------------------------------------------------
-                                                              *NERDTreeIgnore*
+                                                                *NERDTreeIgnore*
 Values: a list of regular expressions.
 Default: ['\~$'].
 
@@ -873,21 +872,21 @@ The file filters can be turned on and off dynamically with the |NERDTree-f|
 mapping.
 
 ------------------------------------------------------------------------------
-                                                   *NERDTreeRespectWildIgnore*
+                                                     *NERDTreeRespectWildIgnore*
 Values: 0 or 1.
 Default: 0.
 
 If set to 1, the `'wildignore'` setting is respected.
 
 ------------------------------------------------------------------------------
-                                                       *NERDTreeBookmarksFile*
+                                                         *NERDTreeBookmarksFile*
 Values: a path
 Default: $HOME/.NERDTreeBookmarks
 
 This is where bookmarks are saved. See |NERDTreeBookmarkCommands|.
 
 ------------------------------------------------------------------------------
-                                                       *NERDTreeBookmarksSort*
+                                                         *NERDTreeBookmarksSort*
 Values: 0, 1, or 2
 Default: 1
 
@@ -899,7 +898,7 @@ If set to 1, the bookmarks list is sorted in a case-insensitive manner.
 If set to 2, the bookmarks list is sorted in a case-sensitive manner.
 
 ------------------------------------------------------------------------------
-                                                       *NERDTreeMarkBookmarks*
+                                                         *NERDTreeMarkBookmarks*
 Values: 0 or 1
 Default: 1
 
@@ -908,7 +907,7 @@ rendered. Users of the |NERDTreeMinimalUI| setting may prefer to disable
 this setting for even less visual clutter.
 
 ------------------------------------------------------------------------------
-                                                           *NERDTreeMouseMode*
+                                                             *NERDTreeMouseMode*
 Values: 1, 2 or 3.
 Default: 1.
 
@@ -926,7 +925,7 @@ then (to single click activate it) you must click somewhere in
 'application.rb'.
 
 ------------------------------------------------------------------------------
-                                                          *NERDTreeQuitOnOpen*
+                                                            *NERDTreeQuitOnOpen*
 
 Values: 0 or 1.
 Default: 0
@@ -935,7 +934,7 @@ If set to 1, the NERD tree window will close after opening a file with the
 |NERDTree-o|, |NERDTree-i|, |NERDTree-t| and |NERDTree-T| mappings.
 
 ------------------------------------------------------------------------------
-                                                       *NERDTreeShowBookmarks*
+                                                         *NERDTreeShowBookmarks*
 Values: 0 or 1.
 Default: 0.
 
@@ -945,7 +944,7 @@ This setting can be toggled dynamically, per tree, with the |NERDTree-B|
 mapping.
 
 ------------------------------------------------------------------------------
-                                                           *NERDTreeShowFiles*
+                                                             *NERDTreeShowFiles*
 Values: 0 or 1.
 Default: 1.
 
@@ -957,7 +956,7 @@ mapping and is useful for drastically shrinking the tree when you are
 navigating to a different part of the tree.
 
 ------------------------------------------------------------------------------
-                                                          *NERDTreeShowHidden*
+                                                            *NERDTreeShowHidden*
 Values: 0 or 1.
 Default: 0.
 
@@ -969,7 +968,7 @@ Use one of the follow lines for this setting: >
 <
 
 ------------------------------------------------------------------------------
-                                                     *NERDTreeShowLineNumbers*
+                                                       *NERDTreeShowLineNumbers*
 Values: 0 or 1.
 Default: 0.
 
@@ -980,7 +979,7 @@ window.  Use one of the follow lines for this setting: >
 <
 
 ------------------------------------------------------------------------------
-                                                           *NERDTreeSortOrder*
+                                                             *NERDTreeSortOrder*
 Values: a list of regular expressions.
 Default: ['\/$', '*', '\.swp$',  '\.bak$', '\~$']
 
@@ -1029,7 +1028,7 @@ Other examples: >
    Each group is shown newest to oldest.
 
 ------------------------------------------------------------------------------
-                                                          *NERDTreeStatusline*
+                                                            *NERDTreeStatusline*
 Values: Any valid `'statusline'` setting.
 Default: %{exists('b:NERDTree')?b:NERDTree.root.path.str():''}
 
@@ -1042,7 +1041,7 @@ Setting this to -1 will deactivate it so that your global `'statusline'`
 setting is used.
 
 ------------------------------------------------------------------------------
-                                                              *NERDTreeWinPos*
+                                                                *NERDTreeWinPos*
 Values: "left" or "right"
 Default: "left".
 
@@ -1054,14 +1053,14 @@ simultaneously. For example, you could have the taglist plugin on the left of
 the window and the NERD tree on the right.
 
 ------------------------------------------------------------------------------
-                                                             *NERDTreeWinSize*
+                                                               *NERDTreeWinSize*
 Values: a positive integer.
 Default: 31.
 
 This setting is used to change the size of the NERD tree when it is loaded.
 
 ------------------------------------------------------------------------------
-                                                           *NERDTreeMinimalUI*
+                                                             *NERDTreeMinimalUI*
 Values: 0 or 1
 Default: 0
 
@@ -1072,7 +1071,7 @@ of the following lines for this setting: >
 <
 
 ------------------------------------------------------------------------------
-                                               *NERDTreeCascadeSingleChildDir*
+                                                 *NERDTreeCascadeSingleChildDir*
 Values: 0 or 1
 Default: 1.
 
@@ -1083,7 +1082,7 @@ have only one child. Use one of the following lines for this setting: >
 <
 
 ------------------------------------------------------------------------------
-                                           *NERDTreeCascadeOpenSingleChildDir*
+                                             *NERDTreeCascadeOpenSingleChildDir*
 Values: 0 or 1
 Default: 1.
 
@@ -1097,7 +1096,7 @@ useful for Java projects. Use one of the following lines for this setting: >
 <
 
 ------------------------------------------------------------------------------
-                                                    *NERDTreeAutoDeleteBuffer*
+                                                      *NERDTreeAutoDeleteBuffer*
 Values: 0 or 1
 Default: 0.
 
@@ -1110,7 +1109,7 @@ following lines for this setting: >
     let NERDTreeAutoDeleteBuffer=1
 <
 ------------------------------------------------------------------------------
-                                                        *NERDTreeCreatePrefix*
+                                                          *NERDTreeCreatePrefix*
 Values: Any valid command prefix.
 Default: "silent".
 
@@ -1121,7 +1120,7 @@ tree window using `silent keepalt keepjumps edit`: >
     let NERDTreeCreatePrefix='silent keepalt keepjumps'
 <
 ------------------------------------------------------------------------------
-                                                       *NERDTreeNodeDelimiter*
+                                                         *NERDTreeNodeDelimiter*
 Values: Any single character.
 Default: "\x07" - the non-printable character BELL.
 
@@ -1145,7 +1144,7 @@ or Unicode. >
 <
 
 ==============================================================================
-4. The NERD tree API                                             *NERDTreeAPI*
+4. The NERD tree API                                               *NERDTreeAPI*
 
 The NERD tree script allows you to add custom key mappings and menu items via
 a set of API calls. Any scripts that use this API should be placed in
@@ -1168,9 +1167,9 @@ See this blog post for more details:
  http://got-ravings.blogspot.com/2008/09/vim-pr0n-prototype-based-objects.html
 
 ------------------------------------------------------------------------------
-4.1. Key map API                                           *NERDTreeKeymapAPI*
+4.1. Key map API                                             *NERDTreeKeymapAPI*
 
-NERDTreeAddKeyMap({options})                             *NERDTreeAddKeyMap()*
+NERDTreeAddKeyMap({options})                               *NERDTreeAddKeyMap()*
     Adds a new keymapping for all NERD tree buffers.
     {options} must be a dictionary, and must contain the following keys:
     "key" - the trigger key for the new mapping
@@ -1210,7 +1209,7 @@ NERDTreeAddKeyMap({options})                             *NERDTreeAddKeyMap()*
 ------------------------------------------------------------------------------
 4.2. Menu API                                                *NERDTreeMenuAPI*
 
-NERDTreeAddSubmenu({options})                           *NERDTreeAddSubmenu()*
+NERDTreeAddSubmenu({options})                             *NERDTreeAddSubmenu()*
     Creates and returns a new submenu.
 
     {options} must be a dictionary and must contain the following keys:
@@ -1227,7 +1226,7 @@ NERDTreeAddSubmenu({options})                           *NERDTreeAddSubmenu()*
 
     See below for an example.
 
-NERDTreeAddMenuItem({options})                         *NERDTreeAddMenuItem()*
+NERDTreeAddMenuItem({options})                           *NERDTreeAddMenuItem()*
     Adds a new menu item to the NERD tree menu (see |NERDTreeMenu|).
 
     {options} must be a dictionary and must contain the
@@ -1247,7 +1246,7 @@ NERDTreeAddMenuItem({options})                         *NERDTreeAddMenuItem()*
 
     See below for an example.
 
-NERDTreeAddMenuSeparator([{options}])             *NERDTreeAddMenuSeparator()*
+NERDTreeAddMenuSeparator([{options}])               *NERDTreeAddMenuSeparator()*
     Adds a menu separator (a row of dashes).
 
     {options} is an optional dictionary that may contain the following keys:
@@ -1290,7 +1289,7 @@ When any of the 3 concrete menu items are selected the function "SomeFunction"
 will be called.
 
 ------------------------------------------------------------------------------
-4.3 NERDTreeAddPathFilter(callback)                  *NERDTreeAddPathFilter()*
+4.3 NERDTreeAddPathFilter(callback)                    *NERDTreeAddPathFilter()*
 
 Path filters are essentially a more powerful version of  |NERDTreeIgnore|.
 If the simple regex matching in |NERDTreeIgnore| is not enough then use
@@ -1307,7 +1306,7 @@ checked against when the decision to ignore them is made. Example >
     endfunction
 <
 ------------------------------------------------------------------------------
-4.4 Path Listener API                                *NERDTreePathListenerAPI*
+4.4 Path Listener API                                  *NERDTreePathListenerAPI*
 
 Use this API if you want to run a callback for events on Path objects. E.G >
 
@@ -1328,12 +1327,12 @@ Current events supported:
   refreshFlags ~
 
 ------------------------------------------------------------------------------
-NERDTreeRender()                                            *NERDTreeRender()*
+NERDTreeRender()                                              *NERDTreeRender()*
     Re-renders the NERD tree buffer. Useful if you change the state of the
     tree and you want to it to be reflected in the UI.
 
 ==============================================================================
-5. About                                                       *NERDTreeAbout*
+5. About                                                         *NERDTreeAbout*
 
 The author of the NERD tree is a terrible terrible monster called Martyzilla
 who gobbles up small children with milk and sugar for breakfast.
@@ -1359,7 +1358,7 @@ Title Credit:
     http://patorjk.com/software/taag/#p=display&f=Rozzo&t=NERDTree
 
 ==============================================================================
-6. License                                                   *NERDTreeLicense*
+6. License                                                     *NERDTreeLicense*
 
 The NERD tree is released under the wtfpl.
 See http://sam.zoy.org/wtfpl/COPYING.

--- a/doc/NERDTree.txt
+++ b/doc/NERDTree.txt
@@ -1,4 +1,4 @@
-*NERDTree.txt*   A tree explorer plugin that owns your momma!
+*NERDTree.txt*   A tree explorer plugin to rule the Vim world. Bwahahaha!!
 
 
 
@@ -1342,10 +1342,13 @@ from you, so feel free to send him suggestions and/or comments about this
 plugin.  Don't be shy --- the worst he can do is slaughter you and stuff you in
 the fridge for later ;)
 
-The latest stable versions can be found at
-    http://www.vim.org/scripts/script.php?script_id=1658
+Martyzilla has convinced two other unsuspecting souls to become his minions in
+his attempt to conquer the Vim plugin world. While Martyzilla may still love to
+receive your emails, the best way to submit suggestions and to report issues
+is, as you may have guessed, to go to
+    http://github.com/scrooloose/nerdtree/issues.
 
-The latest dev versions are on github
+The latest stable and develpment versions are on Github.
     http://github.com/scrooloose/nerdtree
 
 ==============================================================================

--- a/doc/NERDTree.txt
+++ b/doc/NERDTree.txt
@@ -1100,11 +1100,11 @@ useful for Java projects. Use one of the follow lines to set this option: >
 Values: 0 or 1
 Default: 0.
 
-When using a context menu to delete or rename a file you may also want to delete
-the buffer which is no more valid. If the option is not set you will see a
-confirmation if you really want to delete an old buffer. If you always press 'y'
-then it worths to set this option to 1. Use one of the follow lines to set this
-option: >
+When using a context menu to delete or rename a file you may also want to
+delete the buffer which is no more valid. If the option is not set you will
+see a confirmation if you really want to delete an old buffer. If you always
+press 'y' then it worths to set this option to 1. Use one of the follow lines
+to set this option: >
     let NERDTreeAutoDeleteBuffer=0
     let NERDTreeAutoDeleteBuffer=1
 <
@@ -1218,8 +1218,8 @@ NERDTreeAddSubmenu({options})                           *NERDTreeAddSubmenu()*
 
     The following keys are optional:
     "isActiveCallback" - a function that will be called to determine whether
-    this submenu item will be displayed or not. The callback function must return
-    0 or 1.
+    this submenu item will be displayed or not. The callback function must
+    return 0 or 1.
     "parent" - the parent submenu of the new submenu (returned from a previous
     invocation of NERDTreeAddSubmenu()). If this key is left out then the new
     submenu will sit under the top level menu.
@@ -1318,7 +1318,7 @@ Use this API if you want to run a callback for events on Path objects. E.G >
         "This function will be called whenever a Path object is created.
 
         "a:event is an object that contains a bunch of relevant info -
-        "including the path in question. See lib/nerdtree/event.vim for details.
+        "including the affected path. See lib/nerdtree/event.vim for details.
     endfunction
 <
 Current events supported:
@@ -1339,13 +1339,13 @@ who gobbles up small children with milk and sugar for breakfast.
 
 He can be reached at martin.grenfell at gmail dot com. He would love to hear
 from you, so feel free to send him suggestions and/or comments about this
-plugin.  Don't be shy --- the worst he can do is slaughter you and stuff you in
-the fridge for later ;)
+plugin.  Don't be shy --- the worst he can do is slaughter you and stuff you
+in the fridge for later ;)
 
 Martyzilla has convinced two other unsuspecting souls to become his minions in
-his attempt to conquer the Vim plugin world. While Martyzilla may still love to
-receive your emails, the best way to submit suggestions and to report issues
-is, as you may have guessed, to go to
+his attempt to conquer the Vim plugin world. While Martyzilla may still love
+to receive your emails, the best way to submit suggestions and to report
+issues is, as you may have guessed, to go to
     http://github.com/scrooloose/nerdtree/issues.
 
 The latest stable and development versions are on Github.
@@ -1359,4 +1359,4 @@ The NERD tree is released under the wtfpl.
 See http://sam.zoy.org/wtfpl/COPYING.
 
 ------------------------------------------------------------------------------
- vim:tw=78:cc=78:ts=8:ft=help:noet
+ vim:tw=78:ts=8:ft=help:noet

--- a/doc/NERDTree.txt
+++ b/doc/NERDTree.txt
@@ -158,7 +158,7 @@ For example, you could use bookmarks to tag all of your project directories.
 2.2.1. The Bookmark Table                              *NERDTreeBookmarkTable*
 
 If the bookmark table is active (see |NERDTree-B| and
-|'NERDTreeShowBookmarks'|), it will be rendered above the tree. You can double
+|NERDTreeShowBookmarks|), it will be rendered above the tree. You can double
 click bookmarks or use the |NERDTree-o| mapping to activate them. See also,
 |NERDTree-t| and |NERDTree-T|
 
@@ -199,7 +199,7 @@ Note: The following commands are only available within the NERDTree buffer.
     Remove all bookmarks.
 
 :ReadBookmarks
-    Re-read the bookmarks in the |'NERDTreeBookmarksFile'|.
+    Re-read the bookmarks in the |NERDTreeBookmarksFile|.
 
 See also |:NERDTree| and |:NERDTreeFromBookmark|.
 
@@ -210,7 +210,7 @@ If invalid bookmarks are detected, the script will issue an error message and
 the invalid bookmarks will become unavailable for use.
 
 These bookmarks will still be stored in the bookmarks file (see
-|'NERDTreeBookmarksFile'|), down the bottom. There will always be a blank line
+|NERDTreeBookmarksFile|), down the bottom. There will always be a blank line
 after the valid bookmarks but before the invalid ones.
 
 Each line in the bookmarks file represents one bookmark. The proper format is:
@@ -369,8 +369,8 @@ Applies to: directories.
 Recursively opens the selected directory.
 
 All files and directories are cached, but if a directory would not be
-displayed due to file filters (see |'NERDTreeIgnore'| |NERDTree-f|) or the
-hidden file filter (see |'NERDTreeShowHidden'|) then its contents are not
+displayed due to file filters (see |NERDTreeIgnore| |NERDTree-f|) or the
+hidden file filter (see |NERDTreeShowHidden|) then its contents are not
 cached. This is handy, especially if you have .svn directories.
 
 ------------------------------------------------------------------------------
@@ -399,7 +399,7 @@ Applies to: files and directories.
 
 |:edit|s the selected directory, or the selected file's directory. This could
 result in a NERD tree or a netrw being opened, depending on
-|'NERDTreeHijackNetrw'|.
+|NERDTreeHijackNetrw|.
 
 ------------------------------------------------------------------------------
                                                                   *NERDTree-D*
@@ -549,7 +549,7 @@ Default key: f
 Map option: NERDTreeMapToggleFilters
 Applies to: no restrictions.
 
-Toggles whether file filters are used. See |'NERDTreeIgnore'| for details.
+Toggles whether file filters are used. See |NERDTreeIgnore| for details.
 
 ------------------------------------------------------------------------------
                                                                   *NERDTree-F*
@@ -615,97 +615,97 @@ Related tags: |NERDTree-m| |NERDTreeApi|
 The script provides the following options that can customise the behaviour the
 NERD tree. These options should be set in your vimrc.
 
-|'loaded_nerd_tree'|            Turns off the script.
+|loaded_nerd_tree|            Turns off the script.
 
-|'NERDTreeAutoCenter'|          Controls whether the NERD tree window centers
-                                when the cursor moves within a specified
-                                distance to the top/bottom of the window.
+|NERDTreeAutoCenter|          Controls whether the NERD tree window centers
+                              when the cursor moves within a specified
+                              distance to the top/bottom of the window.
 
-|'NERDTreeAutoCenterThreshold'| Controls the sensitivity of autocentering.
+|NERDTreeAutoCenterThreshold| Controls the sensitivity of autocentering.
 
-|'NERDTreeCaseSensitiveSort'|   Tells the NERD tree whether to be case
-                                sensitive or not when sorting nodes.
+|NERDTreeCaseSensitiveSort|   Tells the NERD tree whether to be case
+                              sensitive or not when sorting nodes.
 
-|'NERDTreeNaturalSort'|         Tells the NERD tree whether to use
-                                natural sort order or not when sorting nodes.
+|NERDTreeNaturalSort|         Tells the NERD tree whether to use natural sort
+                              order or not when sorting nodes.
 
-|'NERDTreeSortHiddenFirst'|     Tells the NERD tree whether to take the dot
-                                at the beginning of the hidden file names
-                                into account when sorting nodes.
+|NERDTreeSortHiddenFirst|     Tells the NERD tree whether to take the dot at
+                              the beginning of the hidden file names into
+                              account when sorting nodes.
 
-|'NERDTreeChDirMode'|           Tells the NERD tree if/when it should change
-                                vim's current working directory.
+|NERDTreeChDirMode|           Tells the NERD tree if/when it should change
+                              vim's current working directory.
 
-|'NERDTreeHighlightCursorline'| Tell the NERD tree whether to highlight the
-                                current cursor line.
+|NERDTreeHighlightCursorline| Tell the NERD tree whether to highlight the
+                              current cursor line.
 
-|'NERDTreeHijackNetrw'|         Tell the NERD tree whether to replace the netrw
-                                autocommands for exploring local directories.
+|NERDTreeHijackNetrw|         Tell the NERD tree whether to replace the netrw
+                              autocommands for exploring local directories.
 
-|'NERDTreeIgnore'|              Tells the NERD tree which files to ignore.
+|NERDTreeIgnore|              Tells the NERD tree which files to ignore.
 
-|'NERDTreeRespectWildIgnore'|   Tells the NERD tree to respect |'wildignore'|.
+|NERDTreeRespectWildIgnore|   Tells the NERD tree to respect `'wildignore'`.
 
-|'NERDTreeBookmarksFile'|       Where the bookmarks are stored.
+|NERDTreeBookmarksFile|       Where the bookmarks are stored.
 
-|'NERDTreeBookmarksSort'|       Control how the Bookmark table is sorted.
+|NERDTreeBookmarksSort|       Control how the Bookmark table is sorted.
 
-|'NERDTreeMarkBookmarks'|       Render bookmarked nodes with markers.
+|NERDTreeMarkBookmarks|       Render bookmarked nodes with markers.
 
-|'NERDTreeMouseMode'|           Manage the interpretation of mouse clicks.
+|NERDTreeMouseMode|           Manage the interpretation of mouse clicks.
 
-|'NERDTreeQuitOnOpen'|          Closes the tree window after opening a file.
+|NERDTreeQuitOnOpen|          Closes the tree window after opening a file.
 
-|'NERDTreeShowBookmarks'|       Tells the NERD tree whether to display the
-                                bookmarks table on startup.
+|NERDTreeShowBookmarks|       Tells the NERD tree whether to display the
+                              bookmarks table on startup.
 
-|'NERDTreeShowFiles'|           Tells the NERD tree whether to display files
-                                in the tree on startup.
+|NERDTreeShowFiles|           Tells the NERD tree whether to display files in
+                              the tree on startup.
 
-|'NERDTreeShowHidden'|          Tells the NERD tree whether to display hidden
-                                files on startup.
+|NERDTreeShowHidden|          Tells the NERD tree whether to display hidden
+                              files on startup.
 
-|'NERDTreeShowLineNumbers'|     Tells the NERD tree whether to display line
-                                numbers in the tree window.
+|NERDTreeShowLineNumbers|     Tells the NERD tree whether to display line
+                              numbers in the tree window.
 
-|'NERDTreeSortOrder'|           Tell the NERD tree how to sort the nodes in
-                                the tree.
+|NERDTreeSortOrder|           Tell the NERD tree how to sort the nodes in the
+                              tree.
 
-|'NERDTreeStatusline'|          Set a statusline for NERD tree windows.
+|NERDTreeStatusline|          Set a statusline for NERD tree windows.
 
-|'NERDTreeWinPos'|              Tells the script where to put the NERD tree
-                                window.
+|NERDTreeWinPos|              Tells the script where to put the NERD tree
+                              window.
 
-|'NERDTreeWinSize'|             Sets the window size when the NERD tree is
-                                opened.
+|NERDTreeWinSize|             Sets the window size when the NERD tree is
+                              opened.
 
-|'NERDTreeMinimalUI'|           Disables display of the 'Bookmarks' label and
-                                'Press ? for help' text.
+|NERDTreeMinimalUI|           Disables display of the 'Bookmarks' label and
+                              'Press ? for help' text.
 
-|'NERDTreeCascadeSingleChildDir'|
-                                Collapses on the same line directories that
-                                have only one child directory.
+|NERDTreeCascadeSingleChildDir|
+                              Collapses on the same line directories that have
+                              only one child directory.
 
-|'NERDTreeCascadeOpenSingleChildDir'|
-                                Cascade open while selected directory has only
-                                one child that also is a directory.
+|NERDTreeCascadeOpenSingleChildDir|
+                              Cascade open while selected directory has only
+                              one child that also is a directory.
 
-|'NERDTreeAutoDeleteBuffer'|    Tells the NERD tree to automatically remove
-                                a buffer when a file is being deleted or renamed
-                                via a context menu command.
+|NERDTreeAutoDeleteBuffer|    Tells the NERD tree to automatically remove a
+                              buffer when a file is being deleted or renamed
+                              via a context menu command.
 
-|'NERDTreeCreatePrefix'|        Specify a prefix to be used when creating the
-                                NERDTree window.
+|NERDTreeCreatePrefix|        Specify a prefix to be used when creating the
+                              NERDTree window.
 
-|'NERDTreeRemoveFileCmd'|       Specify a custom shell command to be used when
-                                deleting files. Note that it should include
-                                one space character at the end of the command
-                                and it applies only to files.
+|NERDTreeRemoveFileCmd|       Specify a custom shell command to be used when
+                              deleting files. Note that it should include one
+                              space character at the end of the command and it
+                              applies only to files.
 
-|'NERDTreeRemoveDirCmd'|        Specify a custom shell command to be used when
-                                deleting directories. Note that it should
-                                include one space character at the end of the
-                                command and it applies only to directories.
+|NERDTreeRemoveDirCmd|        Specify a custom shell command to be used when
+                              deleting directories. Note that it should
+                              include one space character at the end of the
+                              command and it applies only to directories.
 
 |NERDTreeNodeDelimiter|       A single character that is used to separate the
                               file or directory name from the rest of the
@@ -717,19 +717,19 @@ NERD tree. These options should be set in your vimrc.
 To enable any of the below options you should put the given line in your
 ~/.vimrc
 
-                                                          *'loaded_nerd_tree'*
+                                                            *loaded_nerd_tree*
 If this plugin is making you feel homicidal, it may be a good idea to turn it
 off with this line in your vimrc: >
     let loaded_nerd_tree=1
 <
 
 ------------------------------------------------------------------------------
-                                                        *'NERDTreeAutoCenter'*
+                                                          *NERDTreeAutoCenter*
 Values: 0 or 1.
 Default: 1
 
 If set to 1, the NERD tree window will center around the cursor if it moves to
-within |'NERDTreeAutoCenterThreshold'| lines of the top/bottom of the window.
+within |NERDTreeAutoCenterThreshold| lines of the top/bottom of the window.
 
 This is ONLY done in response to tree navigation mappings,
 i.e. |NERDTree-J| |NERDTree-K| |NERDTree-C-J| |NERDTree-C-K| |NERDTree-p|
@@ -738,15 +738,15 @@ i.e. |NERDTree-J| |NERDTree-K| |NERDTree-C-J| |NERDTree-C-K| |NERDTree-p|
 The centering is done with a |zz| operation.
 
 ------------------------------------------------------------------------------
-                                               *'NERDTreeAutoCenterThreshold'*
+                                                 *NERDTreeAutoCenterThreshold*
 Values: Any natural number.
 Default: 3
 
 This option controls the "sensitivity" of the NERD tree auto centering. See
-|'NERDTreeAutoCenter'| for details.
+|NERDTreeAutoCenter| for details.
 
 ------------------------------------------------------------------------------
-                                                 *'NERDTreeCaseSensitiveSort'*
+                                                   *NERDTreeCaseSensitiveSort*
 Values: 0 or 1.
 Default: 0.
 
@@ -767,7 +767,7 @@ account. The above nodes would then be sorted like this: >
     boner.c
 <
 ------------------------------------------------------------------------------
-                                                       *'NERDTreeNaturalSort'*
+                                                         *NERDTreeNaturalSort*
 Values: 0 or 1.
 Default: 0.
 
@@ -794,7 +794,7 @@ above nodes would then be sorted like this: >
     z110.txt
 <
 ------------------------------------------------------------------------------
-                                                         *'NERDTreeChDirMode'*
+                                                           *NERDTreeChDirMode*
 
 Values: 0, 1 or 2.
 Default: 0.
@@ -817,15 +817,15 @@ is /home/marty/foobar and you make the node for /home/marty/foobar/baz the new
 root then the CWD will become /home/marty/foobar/baz.
 
 ------------------------------------------------------------------------------
-                                               *'NERDTreeHighlightCursorline'*
+                                                 *NERDTreeHighlightCursorline*
 Values: 0 or 1.
 Default: 1.
 
 If set to 1, the current cursor line in the NERD tree buffer will be
-highlighted. This is done using the |'cursorline'| option.
+highlighted. This is done using the `'cursorline'` option.
 
 ------------------------------------------------------------------------------
-                                                       *'NERDTreeHijackNetrw'*
+                                                         *NERDTreeHijackNetrw*
 Values: 0 or 1.
 Default: 1.
 
@@ -841,13 +841,13 @@ following respects:
     2. you can have one tree per window - instead of per tab.
 
 ------------------------------------------------------------------------------
-                                                            *'NERDTreeIgnore'*
+                                                              *NERDTreeIgnore*
 Values: a list of regular expressions.
 Default: ['\~$'].
 
 This option is used to specify which files the NERD tree should ignore.  It
 must be a list of regular expressions. When the NERD tree is rendered, any
-files/dirs that match any of the regex's in 'NERDTreeIgnore' wont be
+files/dirs that match any of the regex's in NERDTreeIgnore won't be
 displayed.
 
 For example if you put the following line in your vimrc: >
@@ -872,21 +872,21 @@ The file filters can be turned on and off dynamically with the |NERDTree-f|
 mapping.
 
 ------------------------------------------------------------------------------
-                                                *'NERDTreeRespectWildIgnore'*
+                                                   *NERDTreeRespectWildIgnore*
 Values: 0 or 1.
 Default: 0.
 
-If set to 1, the |'wildignore'| setting is respected.
+If set to 1, the `'wildignore'` setting is respected.
 
 ------------------------------------------------------------------------------
-                                                     *'NERDTreeBookmarksFile'*
+                                                       *NERDTreeBookmarksFile*
 Values: a path
 Default: $HOME/.NERDTreeBookmarks
 
 This is where bookmarks are saved. See |NERDTreeBookmarkCommands|.
 
 ------------------------------------------------------------------------------
-                                                     *'NERDTreeBookmarksSort'*
+                                                       *NERDTreeBookmarksSort*
 Values: 0, 1, or 2
 Default: 1
 
@@ -898,16 +898,16 @@ If set to 1, the bookmarks list is sorted in a case-insensitive manner.
 If set to 2, the bookmarks list is sorted in a case-sensitive manner.
 
 ------------------------------------------------------------------------------
-                                                     *'NERDTreeMarkBookmarks'*
+                                                       *NERDTreeMarkBookmarks*
 Values: 0 or 1
 Default: 1
 
 If set to 1, Bookmarks will be specially marked whenever the NERDTree is
-rendered. Users of the |'NERDTreeMinimalUI'| setting may prefer to disable
+rendered. Users of the |NERDTreeMinimalUI| setting may prefer to disable
 this setting for even less visual clutter.
 
 ------------------------------------------------------------------------------
-                                                       *'NERDTreeMouseMode'*
+                                                           *NERDTreeMouseMode*
 Values: 1, 2 or 3.
 Default: 1.
 
@@ -925,7 +925,7 @@ then (to single click activate it) you must click somewhere in
 'application.rb'.
 
 ------------------------------------------------------------------------------
-                                                        *'NERDTreeQuitOnOpen'*
+                                                          *NERDTreeQuitOnOpen*
 
 Values: 0 or 1.
 Default: 0
@@ -934,7 +934,7 @@ If set to 1, the NERD tree window will close after opening a file with the
 |NERDTree-o|, |NERDTree-i|, |NERDTree-t| and |NERDTree-T| mappings.
 
 ------------------------------------------------------------------------------
-                                                     *'NERDTreeShowBookmarks'*
+                                                       *NERDTreeShowBookmarks*
 Values: 0 or 1.
 Default: 0.
 
@@ -944,7 +944,7 @@ This option can be toggled dynamically, per tree, with the |NERDTree-B|
 mapping.
 
 ------------------------------------------------------------------------------
-                                                         *'NERDTreeShowFiles'*
+                                                           *NERDTreeShowFiles*
 Values: 0 or 1.
 Default: 1.
 
@@ -956,7 +956,7 @@ mapping and is useful for drastically shrinking the tree when you are
 navigating to a different part of the tree.
 
 ------------------------------------------------------------------------------
-                                                        *'NERDTreeShowHidden'*
+                                                          *NERDTreeShowHidden*
 Values: 0 or 1.
 Default: 0.
 
@@ -968,7 +968,7 @@ of the follow lines to set this option: >
 <
 
 ------------------------------------------------------------------------------
-                                                   *'NERDTreeShowLineNumbers'*
+                                                     *NERDTreeShowLineNumbers*
 Values: 0 or 1.
 Default: 0.
 
@@ -979,7 +979,7 @@ window.  Use one of the follow lines to set this option: >
 <
 
 ------------------------------------------------------------------------------
-                                                         *'NERDTreeSortOrder'*
+                                                           *NERDTreeSortOrder*
 Values: a list of regular expressions.
 Default: ['\/$', '*', '\.swp$',  '\.bak$', '\~$']
 
@@ -994,7 +994,7 @@ all .h files. All files containing the string 'foobar' will be placed at the
 end.  The star is a special flag: it tells the script that every node that
 doesnt match any of the other regexps should be placed here.
 
-If no star is present in 'NERDTreeSortOrder' then one is automatically
+If no star is present in NERDTreeSortOrder then one is automatically
 appended to the array.
 
 The regex '\/$' should be used to match directory nodes.
@@ -1028,20 +1028,20 @@ Other examples: >
    Each group is shown newest to oldest.
 
 ------------------------------------------------------------------------------
-                                                        *'NERDTreeStatusline'*
-Values: Any valid |'statusline'| setting.
+                                                          *NERDTreeStatusline*
+Values: Any valid `'statusline'` setting.
 Default: %{exists('b:NERDTree')?b:NERDTree.root.path.str():''}
 
-Defines the value for the |'statusline'| setting in NERDTree windows.
+Defines the value for the `'statusline'` setting in NERDTree windows.
 
 Note: The setting is actually applied using |:let-&|, not |:set|, so
 escaping spaces is not necessary.
 
 Setting this option to -1 will deactivate it so that your global
-|'statusline'| setting is used.
+`'statusline'` setting is used.
 
 ------------------------------------------------------------------------------
-                                                            *'NERDTreeWinPos'*
+                                                              *NERDTreeWinPos*
 Values: "left" or "right"
 Default: "left".
 
@@ -1053,14 +1053,14 @@ simultaneously. For example, you could have the taglist plugin on the left of
 the window and the NERD tree on the right.
 
 ------------------------------------------------------------------------------
-                                                           *'NERDTreeWinSize'*
+                                                             *NERDTreeWinSize*
 Values: a positive integer.
 Default: 31.
 
 This option is used to change the size of the NERD tree when it is loaded.
 
 ------------------------------------------------------------------------------
-                                                         *'NERDTreeMinimalUI'*
+                                                           *NERDTreeMinimalUI*
 Values: 0 or 1
 Default: 0
 
@@ -1071,7 +1071,7 @@ of the following lines to set this option: >
 <
 
 ------------------------------------------------------------------------------
-                                             *'NERDTreeCascadeSingleChildDir'*
+                                               *NERDTreeCascadeSingleChildDir*
 Values: 0 or 1
 Default: 1.
 
@@ -1082,7 +1082,7 @@ have only one child. Use one of the follow lines to set this option: >
 <
 
 ------------------------------------------------------------------------------
-                                         *'NERDTreeCascadeOpenSingleChildDir'*
+                                           *NERDTreeCascadeOpenSingleChildDir*
 Values: 0 or 1
 Default: 1.
 
@@ -1096,7 +1096,7 @@ useful for Java projects. Use one of the follow lines to set this option: >
 <
 
 ------------------------------------------------------------------------------
-                                                  *'NERDTreeAutoDeleteBuffer'*
+                                                    *NERDTreeAutoDeleteBuffer*
 Values: 0 or 1
 Default: 0.
 
@@ -1109,14 +1109,14 @@ option: >
     let NERDTreeAutoDeleteBuffer=1
 <
 ------------------------------------------------------------------------------
-                                          *'NERDTreeCreatePrefix'*
+                                                        *NERDTreeCreatePrefix*
 Values: Any valid command prefix.
 Default: "silent".
 
 Internally, NERDTree uses the |:edit| command to create a buffer in which to
 display its tree view. You can augment this behavior by specifying a prefix
 string such as "keepalt" or similar. For example, to have NERDTree create its
-tree window using `silent keepalt keepjumps edit`:
+tree window using `silent keepalt keepjumps edit`: >
     let NERDTreeCreatePrefix='silent keepalt keepjumps'
 <
 ------------------------------------------------------------------------------
@@ -1289,7 +1289,7 @@ When any of the 3 concrete menu items are selected the function "SomeFunction"
 will be called.
 
 ------------------------------------------------------------------------------
-4.3 NERDTreeAddPathFilter(callback)                   *NERDTreeAddPathFilter()*
+4.3 NERDTreeAddPathFilter(callback)                  *NERDTreeAddPathFilter()*
 
 Path filters are essentially a more powerful version of  |NERDTreeIgnore|.
 If the simple regex matching in |NERDTreeIgnore| is not enough then use
@@ -1306,7 +1306,7 @@ checked against when the decision to ignore them is made. Example >
     endfunction
 <
 ------------------------------------------------------------------------------
-4.4 Path Listener API                              *NERDTreePathListenerAPI*
+4.4 Path Listener API                                *NERDTreePathListenerAPI*
 
 Use this API if you want to run a callback for events on Path objects. E.G >
 
@@ -1353,3 +1353,6 @@ The latest dev versions are on github
 
 The NERD tree is released under the wtfpl.
 See http://sam.zoy.org/wtfpl/COPYING.
+
+------------------------------------------------------------------------------
+ vim:tw=78:cc=78:ts=8:ft=help:noet

--- a/doc/NERDTree.txt
+++ b/doc/NERDTree.txt
@@ -28,9 +28,9 @@ CONTENTS                                                   *NERDTree-contents*
             2.2.3.Invalid bookmarks...........|NERDTreeInvalidBookmarks|
         2.3.NERD tree mappings................|NERDTreeMappings|
         2.4.The NERD tree menu................|NERDTreeMenu|
-    3.Options.................................|NERDTreeOptions|
-        3.1.Option summary....................|NERDTreeOptionSummary|
-        3.2.Option details....................|NERDTreeOptionDetails|
+    3.Settings................................|NERDTreeSettings|
+        3.1.Settings summary..................|NERDTreeSettingsSummary|
+        3.2.Settings details..................|NERDTreeSettingsDetails|
     4.The NERD tree API.......................|NERDTreeAPI|
         4.1.Key map API.......................|NERDTreeKeymapAPI|
         4.2.Menu API..........................|NERDTreeMenuAPI|
@@ -273,7 +273,7 @@ A.......Zoom (maximize/minimize) the NERDTree window.............|NERDTree-A|
 ------------------------------------------------------------------------------
                                                                   *NERDTree-o*
 Default key: o
-Map option: NERDTreeMapActivateNode
+Map setting: NERDTreeMapActivateNode
 Applies to: files and directories.
 
 If a file node is selected, it is opened in the previous window.
@@ -290,7 +290,7 @@ previous window.
 ------------------------------------------------------------------------------
                                                                  *NERDTree-go*
 Default key: go
-Map option: NERDTreeMapPreview
+Map setting: NERDTreeMapPreview
 Applies to: files.
 
 If a file node is selected, it is opened in the previous window, but the
@@ -302,7 +302,7 @@ The default key combo for this mapping is "g" + NERDTreeMapActivateNode (see
 ------------------------------------------------------------------------------
                                                                   *NERDTree-t*
 Default key: t
-Map option: NERDTreeMapOpenInTab
+Map setting: NERDTreeMapOpenInTab
 Applies to: files and directories.
 
 Opens the selected file in a new tab. If a directory is selected, a fresh
@@ -315,7 +315,7 @@ in a new tab.
 ------------------------------------------------------------------------------
                                                                   *NERDTree-T*
 Default key: T
-Map option: NERDTreeMapOpenInTabSilent
+Map setting: NERDTreeMapOpenInTabSilent
 Applies to: files and directories.
 
 The same as |NERDTree-t| except that the focus is kept in the current tab.
@@ -323,7 +323,7 @@ The same as |NERDTree-t| except that the focus is kept in the current tab.
 ------------------------------------------------------------------------------
                                                                   *NERDTree-i*
 Default key: i
-Map option: NERDTreeMapOpenSplit
+Map setting: NERDTreeMapOpenSplit
 Applies to: files.
 
 Opens the selected file in a new split window and puts the cursor in the new
@@ -332,7 +332,7 @@ window.
 ------------------------------------------------------------------------------
                                                                  *NERDTree-gi*
 Default key: gi
-Map option: NERDTreeMapPreviewSplit
+Map setting: NERDTreeMapPreviewSplit
 Applies to: files.
 
 The same as |NERDTree-i| except that the cursor is not moved.
@@ -343,16 +343,16 @@ The default key combo for this mapping is "g" + NERDTreeMapOpenSplit (see
 ------------------------------------------------------------------------------
                                                                   *NERDTree-s*
 Default key: s
-Map option: NERDTreeMapOpenVSplit
+Map setting: NERDTreeMapOpenVSplit
 Applies to: files.
 
-Opens the selected file in a new vertically split window and puts the cursor in
-the new window.
+Opens the selected file in a new vertically split window and puts the cursor
+in the new window.
 
 ------------------------------------------------------------------------------
                                                                  *NERDTree-gs*
 Default key: gs
-Map option: NERDTreeMapPreviewVSplit
+Map setting: NERDTreeMapPreviewVSplit
 Applies to: files.
 
 The same as |NERDTree-s| except that the cursor is not moved.
@@ -363,7 +363,7 @@ The default key combo for this mapping is "g" + NERDTreeMapOpenVSplit (see
 ------------------------------------------------------------------------------
                                                                   *NERDTree-O*
 Default key: O
-Map option: NERDTreeMapOpenRecursively
+Map setting: NERDTreeMapOpenRecursively
 Applies to: directories.
 
 Recursively opens the selected directory.
@@ -376,7 +376,7 @@ cached. This is handy, especially if you have .svn directories.
 ------------------------------------------------------------------------------
                                                                   *NERDTree-x*
 Default key: x
-Map option: NERDTreeMapCloseDir
+Map setting: NERDTreeMapCloseDir
 Applies to: files and directories.
 
 Closes the parent of the selected node.
@@ -384,7 +384,7 @@ Closes the parent of the selected node.
 ------------------------------------------------------------------------------
                                                                   *NERDTree-X*
 Default key: X
-Map option: NERDTreeMapCloseChildren
+Map setting: NERDTreeMapCloseChildren
 Applies to: directories.
 
 Recursively closes all children of the selected directory.
@@ -394,7 +394,7 @@ Tip: To quickly "reset" the tree, use |NERDTree-P| with this mapping.
 ------------------------------------------------------------------------------
                                                                   *NERDTree-e*
 Default key: e
-Map option: NERDTreeMapOpenExpl
+Map setting: NERDTreeMapOpenExpl
 Applies to: files and directories.
 
 |:edit|s the selected directory, or the selected file's directory. This could
@@ -404,7 +404,7 @@ result in a NERD tree or a netrw being opened, depending on
 ------------------------------------------------------------------------------
                                                                   *NERDTree-D*
 Default key: D
-Map option: NERDTreeMapDeleteBookmark
+Map setting: NERDTreeMapDeleteBookmark
 Applies to: lines in the bookmarks table
 
 Deletes the currently selected bookmark.
@@ -412,7 +412,7 @@ Deletes the currently selected bookmark.
 ------------------------------------------------------------------------------
                                                                   *NERDTree-P*
 Default key: P
-Map option: NERDTreeMapJumpRoot
+Map setting: NERDTreeMapJumpRoot
 Applies to: no restrictions.
 
 Jump to the tree root.
@@ -420,7 +420,7 @@ Jump to the tree root.
 ------------------------------------------------------------------------------
                                                                   *NERDTree-p*
 Default key: p
-Map option: NERDTreeMapJumpParent
+Map setting: NERDTreeMapJumpParent
 Applies to: files and directories.
 
 Jump to the parent node of the selected node.
@@ -428,7 +428,7 @@ Jump to the parent node of the selected node.
 ------------------------------------------------------------------------------
                                                                   *NERDTree-K*
 Default key: K
-Map option: NERDTreeMapJumpFirstChild
+Map setting: NERDTreeMapJumpFirstChild
 Applies to: files and directories.
 
 Jump to the first child of the current nodes parent.
@@ -441,7 +441,7 @@ If the cursor is already on the first node then do the following:
 ------------------------------------------------------------------------------
                                                                   *NERDTree-J*
 Default key: J
-Map option: NERDTreeMapJumpLastChild
+Map setting: NERDTreeMapJumpLastChild
 Applies to: files and directories.
 
 Jump to the last child of the current nodes parent.
@@ -454,7 +454,7 @@ If the cursor is already on the last node then do the following:
 ------------------------------------------------------------------------------
                                                                 *NERDTree-C-J*
 Default key: <C-J>
-Map option: NERDTreeMapJumpNextSibling
+Map setting: NERDTreeMapJumpNextSibling
 Applies to: files and directories.
 
 Jump to the next sibling of the selected node.
@@ -462,7 +462,7 @@ Jump to the next sibling of the selected node.
 ------------------------------------------------------------------------------
                                                                 *NERDTree-C-K*
 Default key: <C-K>
-Map option: NERDTreeMapJumpPrevSibling
+Map setting: NERDTreeMapJumpPrevSibling
 Applies to: files and directories.
 
 Jump to the previous sibling of the selected node.
@@ -470,7 +470,7 @@ Jump to the previous sibling of the selected node.
 ------------------------------------------------------------------------------
                                                                   *NERDTree-C*
 Default key: C
-Map option: NERDTreeMapChangeRoot
+Map setting: NERDTreeMapChangeRoot
 Applies to: files and directories.
 
 Make the selected directory node the new tree root. If a file is selected, its
@@ -479,7 +479,7 @@ parent is used.
 ------------------------------------------------------------------------------
                                                                   *NERDTree-u*
 Default key: u
-Map option: NERDTreeMapUpdir
+Map setting: NERDTreeMapUpdir
 Applies to: no restrictions.
 
 Move the tree root up a dir (like doing a "cd ..").
@@ -487,7 +487,7 @@ Move the tree root up a dir (like doing a "cd ..").
 ------------------------------------------------------------------------------
                                                                   *NERDTree-U*
 Default key: U
-Map option: NERDTreeMapUpdirKeepOpen
+Map setting: NERDTreeMapUpdirKeepOpen
 Applies to: no restrictions.
 
 Like |NERDTree-u| except that the old tree root is kept open.
@@ -495,7 +495,7 @@ Like |NERDTree-u| except that the old tree root is kept open.
 ------------------------------------------------------------------------------
                                                                   *NERDTree-r*
 Default key: r
-Map option: NERDTreeMapRefresh
+Map setting: NERDTreeMapRefresh
 Applies to: files and directories.
 
 If a dir is selected, recursively refresh that dir, i.e. scan the filesystem
@@ -506,7 +506,7 @@ If a file node is selected then the above is done on it's parent.
 ------------------------------------------------------------------------------
                                                                   *NERDTree-R*
 Default key: R
-Map option: NERDTreeMapRefreshRoot
+Map setting: NERDTreeMapRefreshRoot
 Applies to: no restrictions.
 
 Recursively refresh the tree root.
@@ -514,7 +514,7 @@ Recursively refresh the tree root.
 ------------------------------------------------------------------------------
                                                                   *NERDTree-m*
 Default key: m
-Map option: NERDTreeMapMenu
+Map setting: NERDTreeMapMenu
 Applies to: files and directories.
 
 Display the NERD tree menu. See |NERDTreeMenu| for details.
@@ -522,7 +522,7 @@ Display the NERD tree menu. See |NERDTreeMenu| for details.
 ------------------------------------------------------------------------------
                                                                  *NERDTree-cd*
 Default key: cd
-Map option: NERDTreeMapChdir
+Map setting: NERDTreeMapChdir
 Applies to: files and directories.
 
 Change Vim's current working directory to that of the selected node.
@@ -530,7 +530,7 @@ Change Vim's current working directory to that of the selected node.
 ------------------------------------------------------------------------------
                                                                  *NERDTree-CD*
 Default key: CD
-Map option: NERDTreeMapCWD
+Map setting: NERDTreeMapCWD
 Applies to: no restrictions.
 
 Change the NERDTree root to Vim's current working directory.
@@ -538,7 +538,7 @@ Change the NERDTree root to Vim's current working directory.
 ------------------------------------------------------------------------------
                                                                   *NERDTree-I*
 Default key: I
-Map option: NERDTreeMapToggleHidden
+Map setting: NERDTreeMapToggleHidden
 Applies to: no restrictions.
 
 Toggles whether hidden files (i.e. "dot files") are displayed.
@@ -546,7 +546,7 @@ Toggles whether hidden files (i.e. "dot files") are displayed.
 ------------------------------------------------------------------------------
                                                                   *NERDTree-f*
 Default key: f
-Map option: NERDTreeMapToggleFilters
+Map setting: NERDTreeMapToggleFilters
 Applies to: no restrictions.
 
 Toggles whether file filters are used. See |NERDTreeIgnore| for details.
@@ -554,7 +554,7 @@ Toggles whether file filters are used. See |NERDTreeIgnore| for details.
 ------------------------------------------------------------------------------
                                                                   *NERDTree-F*
 Default key: F
-Map option: NERDTreeMapToggleFiles
+Map setting: NERDTreeMapToggleFiles
 Applies to: no restrictions.
 
 Toggles whether file nodes are displayed.
@@ -562,7 +562,7 @@ Toggles whether file nodes are displayed.
 ------------------------------------------------------------------------------
                                                                   *NERDTree-B*
 Default key: B
-Map option: NERDTreeMapToggleBookmarks
+Map setting: NERDTreeMapToggleBookmarks
 Applies to: no restrictions.
 
 Toggles whether the bookmarks table is displayed.
@@ -570,7 +570,7 @@ Toggles whether the bookmarks table is displayed.
 ------------------------------------------------------------------------------
                                                                   *NERDTree-q*
 Default key: q
-Map option: NERDTreeMapQuit
+Map setting: NERDTreeMapQuit
 Applies to: no restrictions.
 
 Closes the NERDtree window.
@@ -578,7 +578,7 @@ Closes the NERDtree window.
 ------------------------------------------------------------------------------
                                                                   *NERDTree-A*
 Default key: A
-Map option: NERDTreeMapToggleZoom
+Map setting: NERDTreeMapToggleZoom
 Applies to: no restrictions.
 
 Maximize (zoom) and minimize the NERDtree window.
@@ -586,7 +586,7 @@ Maximize (zoom) and minimize the NERDtree window.
 ------------------------------------------------------------------------------
                                                                   *NERDTree-?*
 Default key: ?
-Map option: NERDTreeMapHelp
+Map setting: NERDTreeMapHelp
 Applies to: no restrictions.
 
 Toggles whether the quickhelp is displayed.
@@ -606,14 +606,14 @@ menu item to execute executable files.
 Related tags: |NERDTree-m| |NERDTreeApi|
 
 ==============================================================================
-3. Customisation                                             *NERDTreeOptions*
+3. Customisation                                            *NERDTreeSettings*
 
 
 ------------------------------------------------------------------------------
-3.1. Customisation summary                             *NERDTreeOptionSummary*
+3.1. Customisation summary                           *NERDTreeSettingsSummary*
 
-The script provides the following options that can customise the behaviour the
-NERD tree. These options should be set in your vimrc.
+The plugin provides the following settings that can customise the behaviour
+the NERD tree. These settings should be set in your vimrc, using `:let`.
 
 |loaded_nerd_tree|            Turns off the script.
 
@@ -712,10 +712,11 @@ NERD tree. These options should be set in your vimrc.
                               characters on the line of text.
 
 ------------------------------------------------------------------------------
-3.2. Customisation details                             *NERDTreeOptionDetails*
+3.2. Customisation details                           *NERDTreeSettingsDetails*
 
-To enable any of the below options you should put the given line in your
-~/.vimrc
+To enable any of the below settings you should put an appropriate >
+    let <setting>=<value>
+<line in your ~/.vimrc.
 
                                                             *loaded_nerd_tree*
 If this plugin is making you feel homicidal, it may be a good idea to turn it
@@ -742,7 +743,7 @@ The centering is done with a |zz| operation.
 Values: Any natural number.
 Default: 3
 
-This option controls the "sensitivity" of the NERD tree auto centering. See
+This setting controls the "sensitivity" of the NERD tree auto centering. See
 |NERDTreeAutoCenter| for details.
 
 ------------------------------------------------------------------------------
@@ -758,8 +759,8 @@ could appear like this: >
     boner.c
     Foo.c
 <
-But, if you set this option to 1 then the case of the nodes will be taken into
-account. The above nodes would then be sorted like this: >
+But, if you set this setting to 1 then the case of the nodes will be taken
+into account. The above nodes would then be sorted like this: >
     Baz.c
     Foo.c
     bar.c
@@ -782,7 +783,7 @@ could appear like this: >
     z20.txt
     z3.txt
 <
-But if you set this option to 1 then the natural sort order will be used. The
+But if you set this setting to 1 then the natural sort order will be used. The
 above nodes would then be sorted like this: >
     z1.txt
     z2.txt
@@ -799,7 +800,7 @@ above nodes would then be sorted like this: >
 Values: 0, 1 or 2.
 Default: 0.
 
-Use this option to tell the script when (if at all) to change the current
+Use this setting to tell the script when (if at all) to change the current
 working directory (CWD) for vim.
 
 If it is set to 0 then the CWD is never changed by the NERD tree.
@@ -811,7 +812,7 @@ directory it is initialized in. For example, if you start the NERD tree with >
 then the CWD will be changed to /home/marty/foobar and will not be changed
 again unless you init another NERD tree with a similar command.
 
-If the option is set to 2 then it behaves the same as if set to 1 except that
+If the setting is set to 2 then it behaves the same as if set to 1 except that
 the CWD is changed whenever the tree root is changed. For example, if the CWD
 is /home/marty/foobar and you make the node for /home/marty/foobar/baz the new
 root then the CWD will become /home/marty/foobar/baz.
@@ -822,7 +823,7 @@ Values: 0 or 1.
 Default: 1.
 
 If set to 1, the current cursor line in the NERD tree buffer will be
-highlighted. This is done using the `'cursorline'` option.
+highlighted. This is done using the `'cursorline'` Vim option.
 
 ------------------------------------------------------------------------------
                                                          *NERDTreeHijackNetrw*
@@ -845,7 +846,7 @@ following respects:
 Values: a list of regular expressions.
 Default: ['\~$'].
 
-This option is used to specify which files the NERD tree should ignore.  It
+This setting is used to specify which files the NERD tree should ignore.  It
 must be a list of regular expressions. When the NERD tree is rendered, any
 files/dirs that match any of the regex's in NERDTreeIgnore won't be
 displayed.
@@ -890,7 +891,7 @@ This is where bookmarks are saved. See |NERDTreeBookmarkCommands|.
 Values: 0, 1, or 2
 Default: 1
 
-This option controls the method by which the list of user bookmarks is
+This setting controls the method by which the list of user bookmarks is
 sorted. When sorted, bookmarks will render in alphabetical order by name.
 
 If set to 0, the bookmarks list is not sorted.
@@ -938,9 +939,9 @@ If set to 1, the NERD tree window will close after opening a file with the
 Values: 0 or 1.
 Default: 0.
 
-If this option is set to 1 then the bookmarks table will be displayed.
+If this setting is set to 1 then the bookmarks table will be displayed.
 
-This option can be toggled dynamically, per tree, with the |NERDTree-B|
+This setting can be toggled dynamically, per tree, with the |NERDTree-B|
 mapping.
 
 ------------------------------------------------------------------------------
@@ -948,10 +949,10 @@ mapping.
 Values: 0 or 1.
 Default: 1.
 
-If this option is set to 1 then files are displayed in the NERD tree. If it is
-set to 0 then only directories are displayed.
+If this setting is set to 1 then files are displayed in the NERD tree. If it
+is set to 0 then only directories are displayed.
 
-This option can be toggled dynamically, per tree, with the |NERDTree-F|
+This setting can be toggled dynamically, per tree, with the |NERDTree-F|
 mapping and is useful for drastically shrinking the tree when you are
 navigating to a different part of the tree.
 
@@ -960,9 +961,9 @@ navigating to a different part of the tree.
 Values: 0 or 1.
 Default: 0.
 
-This option tells vim whether to display hidden files by default. This option
-can be dynamically toggled, per tree, with the |NERDTree-I| mapping.  Use one
-of the follow lines to set this option: >
+This setting tells vim whether to display hidden files by default. This
+setting can be dynamically toggled, per tree, with the |NERDTree-I| mapping.
+Use one of the follow lines for this setting: >
     let NERDTreeShowHidden=0
     let NERDTreeShowHidden=1
 <
@@ -972,8 +973,8 @@ of the follow lines to set this option: >
 Values: 0 or 1.
 Default: 0.
 
-This option tells vim whether to display line numbers for the NERD tree
-window.  Use one of the follow lines to set this option: >
+This setting tells vim whether to display line numbers for the NERD tree
+window.  Use one of the follow lines for this setting: >
     let NERDTreeShowLineNumbers=0
     let NERDTreeShowLineNumbers=1
 <
@@ -983,10 +984,10 @@ window.  Use one of the follow lines to set this option: >
 Values: a list of regular expressions.
 Default: ['\/$', '*', '\.swp$',  '\.bak$', '\~$']
 
-This option is set to a list of regular expressions which are used to
-specify the order of nodes under their parent.
+This setting is a list of regular expressions which are used to specify the
+order of nodes under their parent.
 
-For example, if the option is set to: >
+For example, if the setting is: >
     ['\.vim$', '\.c$', '\.h$', '*', 'foobar']
 <
 then all .vim files will be placed at the top, followed by all .c files then
@@ -1037,18 +1038,18 @@ Defines the value for the `'statusline'` setting in NERDTree windows.
 Note: The setting is actually applied using |:let-&|, not |:set|, so
 escaping spaces is not necessary.
 
-Setting this option to -1 will deactivate it so that your global
-`'statusline'` setting is used.
+Setting this to -1 will deactivate it so that your global `'statusline'`
+setting is used.
 
 ------------------------------------------------------------------------------
                                                               *NERDTreeWinPos*
 Values: "left" or "right"
 Default: "left".
 
-This option is used to determine where NERD tree window is placed on the
+This setting is used to determine where NERD tree window is placed on the
 screen.
 
-This option makes it possible to use two different explorer plugins
+This setting makes it possible to use two different explorer plugins
 simultaneously. For example, you could have the taglist plugin on the left of
 the window and the NERD tree on the right.
 
@@ -1057,15 +1058,15 @@ the window and the NERD tree on the right.
 Values: a positive integer.
 Default: 31.
 
-This option is used to change the size of the NERD tree when it is loaded.
+This setting is used to change the size of the NERD tree when it is loaded.
 
 ------------------------------------------------------------------------------
                                                            *NERDTreeMinimalUI*
 Values: 0 or 1
 Default: 0
 
-This options disables the 'Bookmarks' label 'Press ? for help' text. Use one
-of the following lines to set this option: >
+This setting disables the 'Bookmarks' label 'Press ? for help' text. Use one
+of the following lines for this setting: >
     let NERDTreeMinimalUI=0
     let NERDTreeMinimalUI=1
 <
@@ -1075,8 +1076,8 @@ of the following lines to set this option: >
 Values: 0 or 1
 Default: 1.
 
-When displaying dir nodes, this option tells NERDTree to collapse dirs that
-have only one child. Use one of the follow lines to set this option: >
+When displaying dir nodes, this setting tells NERDTree to collapse dirs that
+have only one child. Use one of the following lines for this setting: >
     let NERDTreeCascadeSingleChildDir=0
     let NERDTreeCascadeSingleChildDir=1
 <
@@ -1086,11 +1087,11 @@ have only one child. Use one of the follow lines to set this option: >
 Values: 0 or 1
 Default: 1.
 
-When opening dir nodes, this option tells NERDTree to recursively open dirs
+When opening dir nodes, this setting tells NERDTree to recursively open dirs
 that have only one child which is also a dir. NERDTree will stop when it finds
-a dir that contains anything but another single dir. This option also causes
-the |NERDTree-x| mapping to close dirs in the same manner. This option may be
-useful for Java projects. Use one of the follow lines to set this option: >
+a dir that contains anything but another single dir. This setting also causes
+the |NERDTree-x| mapping to close dirs in the same manner. This setting may be
+useful for Java projects. Use one of the following lines for this setting: >
     let NERDTreeCascadeOpenSingleChildDir=0
     let NERDTreeCascadeOpenSingleChildDir=1
 <
@@ -1101,10 +1102,10 @@ Values: 0 or 1
 Default: 0.
 
 When using a context menu to delete or rename a file you may also want to
-delete the buffer which is no more valid. If the option is not set you will
+delete the buffer which is no more valid. If the setting is not set you will
 see a confirmation if you really want to delete an old buffer. If you always
-press 'y' then it worths to set this option to 1. Use one of the follow lines
-to set this option: >
+press 'y' then it's worth it to set this setting to 1. Use one of the
+following lines for this setting: >
     let NERDTreeAutoDeleteBuffer=0
     let NERDTreeAutoDeleteBuffer=1
 <
@@ -1130,14 +1131,14 @@ characters that are otherwise used in the NERDTree, such as square brackets,
 braces, trailing asterisk, and leading space. For more details see the
 resoponsible pull request: https://github.com/scrooloose/nerdtree/pull/868.
 
-The default should work in nearly every situation, but this option exists for
+The default should work in nearly every situation, but this setting exists for
 those very rare cases where it doesn't. "\x07" was chosen because it's
 non-printable, and very unlikely to be used purposefully in a filename or as a
 flag by other NERDTree plugins. If you need to change the delimiter, be sure
 to choose a character that won't appear in your filenames or any of the flags
 set by your installed NERDTree plugins. The suggestions below are but a few of
-the many options. Remember to use double quotes when specifying by hex or
-Unicode. >
+the many possibilities. Remember to use double quotes when specifying by hex
+or Unicode. >
     let NERDTreeNodeDelimiter='😀'
     let NERDTreeNodeDelimiter="\u00a0"
     let NERDTreeNodeDelimiter="\xFF"

--- a/doc/NERDTree.txt
+++ b/doc/NERDTree.txt
@@ -617,29 +617,29 @@ the NERD tree. These settings should be set in your vimrc, using `:let`.
 |loaded_nerd_tree|            Turns off the script.
 
 |NERDTreeAutoCenter|          Controls whether the NERD tree window centers
-                              when the cursor moves within a specified
-                              distance to the top/bottom of the window.
+                            when the cursor moves within a specified
+                            distance to the top/bottom of the window.
 
 |NERDTreeAutoCenterThreshold| Controls the sensitivity of autocentering.
 
 |NERDTreeCaseSensitiveSort|   Tells the NERD tree whether to be case
-                              sensitive or not when sorting nodes.
+                            sensitive or not when sorting nodes.
 
 |NERDTreeNaturalSort|         Tells the NERD tree whether to use natural sort
-                              order or not when sorting nodes.
+                            order or not when sorting nodes.
 
 |NERDTreeSortHiddenFirst|     Tells the NERD tree whether to take the dot at
-                              the beginning of the hidden file names into
-                              account when sorting nodes.
+                            the beginning of the hidden file names into
+                            account when sorting nodes.
 
 |NERDTreeChDirMode|           Tells the NERD tree if/when it should change
-                              vim's current working directory.
+                            vim's current working directory.
 
 |NERDTreeHighlightCursorline| Tell the NERD tree whether to highlight the
-                              current cursor line.
+                            current cursor line.
 
 |NERDTreeHijackNetrw|         Tell the NERD tree whether to replace the netrw
-                              autocommands for exploring local directories.
+                            autocommands for exploring local directories.
 
 |NERDTreeIgnore|              Tells the NERD tree which files to ignore.
 
@@ -656,59 +656,59 @@ the NERD tree. These settings should be set in your vimrc, using `:let`.
 |NERDTreeQuitOnOpen|          Closes the tree window after opening a file.
 
 |NERDTreeShowBookmarks|       Tells the NERD tree whether to display the
-                              bookmarks table on startup.
+                            bookmarks table on startup.
 
 |NERDTreeShowFiles|           Tells the NERD tree whether to display files in
-                              the tree on startup.
+                            the tree on startup.
 
 |NERDTreeShowHidden|          Tells the NERD tree whether to display hidden
-                              files on startup.
+                            files on startup.
 
 |NERDTreeShowLineNumbers|     Tells the NERD tree whether to display line
-                              numbers in the tree window.
+                            numbers in the tree window.
 
 |NERDTreeSortOrder|           Tell the NERD tree how to sort the nodes in the
-                              tree.
+                            tree.
 
 |NERDTreeStatusline|          Set a statusline for NERD tree windows.
 
 |NERDTreeWinPos|              Tells the script where to put the NERD tree
-                              window.
+                            window.
 
 |NERDTreeWinSize|             Sets the window size when the NERD tree is
-                              opened.
+                            opened.
 
 |NERDTreeMinimalUI|           Disables display of the 'Bookmarks' label and
-                              'Press ? for help' text.
+                            'Press ? for help' text.
 
 |NERDTreeCascadeSingleChildDir|
-                              Collapses on the same line directories that have
-                              only one child directory.
+                            Collapses on the same line directories that have
+                            only one child directory.
 
 |NERDTreeCascadeOpenSingleChildDir|
-                              Cascade open while selected directory has only
-                              one child that also is a directory.
+                            Cascade open while selected directory has only
+                            one child that also is a directory.
 
 |NERDTreeAutoDeleteBuffer|    Tells the NERD tree to automatically remove a
-                              buffer when a file is being deleted or renamed
-                              via a context menu command.
+                            buffer when a file is being deleted or renamed
+                            via a context menu command.
 
 |NERDTreeCreatePrefix|        Specify a prefix to be used when creating the
-                              NERDTree window.
+                            NERDTree window.
 
 |NERDTreeRemoveFileCmd|       Specify a custom shell command to be used when
-                              deleting files. Note that it should include one
-                              space character at the end of the command and it
-                              applies only to files.
+                            deleting files. Note that it should include one
+                            space character at the end of the command and it
+                            applies only to files.
 
 |NERDTreeRemoveDirCmd|        Specify a custom shell command to be used when
-                              deleting directories. Note that it should
-                              include one space character at the end of the
-                              command and it applies only to directories.
+                            deleting directories. Note that it should
+                            include one space character at the end of the
+                            command and it applies only to directories.
 
 |NERDTreeNodeDelimiter|       A single character that is used to separate the
-                              file or directory name from the rest of the
-                              characters on the line of text.
+                            file or directory name from the rest of the
+                            characters on the line of text.
 
 ------------------------------------------------------------------------------
 3.2. Customisation details                             *NERDTreeSettingsDetails*
@@ -992,7 +992,7 @@ For example, if the setting is: >
 then all .vim files will be placed at the top, followed by all .c files then
 all .h files. All files containing the string 'foobar' will be placed at the
 end.  The star is a special flag: it tells the script that every node that
-doesnt match any of the other regexps should be placed here.
+doesn't match any of the other regexps should be placed here.
 
 If no star is present in NERDTreeSortOrder then one is automatically
 appended to the array.
@@ -1008,7 +1008,7 @@ done secondarily. See examples 4, 5, and 6 below.
 
 After this sorting is done, the files in each group are sorted alphabetically.
 
-Other examples: >
+Examples: >
     (1) ['*', '\/$']
     (2) []
     (3) ['\/$', '\.rb$', '\.php$', '*', '\.swp$',  '\.bak$', '\~$']
@@ -1127,7 +1127,7 @@ Default: "\x07" - the non-printable character BELL.
 This character is used to separate the file or directory name from the rest of
 the characters in the line of text. It allows filenames to contain special
 characters that are otherwise used in the NERDTree, such as square brackets,
-braces, trailing asterisk, and leading space. For more details see the
+braces, trailing asterisk, and leading space. For more details, see the
 resoponsible pull request: https://github.com/scrooloose/nerdtree/pull/868.
 
 The default should work in nearly every situation, but this setting exists for
@@ -1342,14 +1342,13 @@ from you, so feel free to send him suggestions and/or comments about this
 plugin.  Don't be shy --- the worst he can do is slaughter you and stuff you
 in the fridge for later ;)
 
-Martyzilla has convinced two other unsuspecting souls to become his minions in
-his attempt to conquer the Vim plugin world. While Martyzilla may still love
-to receive your emails, the best way to submit suggestions and to report
-issues is, as you may have guessed, to go to
-    http://github.com/scrooloose/nerdtree/issues.
+Martyzilla recruited two other unwitting accomplices to become his minions in
+his quest to conquer the Vim plugin world. While he may still love to receive
+your emails, the best way to send suggestions, bug reports, and questions is
+to submit an issue at http://github.com/scrooloose/nerdtree/issues.
 
 The latest stable and development versions are on Github.
-    Stable: http://github.com/scrooloose/nerdtree
+    Stable: http://github.com/scrooloose/nerdtree (master branch)
     Development: http://github.com/scrooloose/nerdtree/branches
 
 Title Credit:

--- a/doc/NERDTree.txt
+++ b/doc/NERDTree.txt
@@ -707,6 +707,10 @@ NERD tree. These options should be set in your vimrc.
                                 include one space character at the end of the
                                 command and it applies only to directories.
 
+|NERDTreeNodeDelimiter|       A single character that is used to separate the
+                              file or directory name from the rest of the
+                              characters on the line of text.
+
 ------------------------------------------------------------------------------
 3.2. Customisation details                             *NERDTreeOptionDetails*
 
@@ -1114,6 +1118,29 @@ display its tree view. You can augment this behavior by specifying a prefix
 string such as "keepalt" or similar. For example, to have NERDTree create its
 tree window using `silent keepalt keepjumps edit`:
     let NERDTreeCreatePrefix='silent keepalt keepjumps'
+<
+------------------------------------------------------------------------------
+                                                       *NERDTreeNodeDelimiter*
+Values: Any single character.
+Default: "\x07" - the non-printable character BELL.
+
+This character is used to separate the file or directory name from the rest of
+the characters in the line of text. It allows filenames to contain special
+characters that are otherwise used in the NERDTree, such as square brackets,
+braces, trailing asterisk, and leading space. For more details see the
+resoponsible pull request: https://github.com/scrooloose/nerdtree/pull/868.
+
+The default should work in nearly every situation, but this option exists for
+those very rare cases where it doesn't. "\x07" was chosen because it's
+non-printable, and very unlikely to be used purposefully in a filename or as a
+flag by other NERDTree plugins. If you need to change the delimiter, be sure
+to choose a character that won't appear in your filenames or any of the flags
+set by your installed NERDTree plugins. The suggestions below are but a few of
+the many options. Remember to use double quotes when specifying by hex or
+Unicode. >
+    let NERDTreeNodeDelimiter='😀'
+    let NERDTreeNodeDelimiter="\u00a0"
+    let NERDTreeNodeDelimiter="\xFF"
 <
 
 ==============================================================================

--- a/plugin/NERD_tree.vim
+++ b/plugin/NERD_tree.vim
@@ -86,8 +86,8 @@ let g:NERDTreeOldSortOrder = []
 
 call s:initVariable("g:NERDTreeGlyphReadOnly", "RO")
 
-" ASCII 160: non-breaking space used to delimit items in the tree's nodes.
-call s:initVariable("g:NERDTreeNodeDelimiter", "\u00a0")
+" ASCII 7: bell non-printing character used to delimit items in the tree's nodes.
+call s:initVariable("g:NERDTreeNodeDelimiter", "\x07")
 
 if !exists('g:NERDTreeStatusline')
 

--- a/syntax/nerdtree.vim
+++ b/syntax/nerdtree.vim
@@ -38,10 +38,10 @@ syn match NERDTreeFlags #\[[^\]]*\]# containedin=NERDTreeDir
 
 "highlighing to conceal the delimiter around the file/dir name
 if has("conceal")
-    exec 'syn match NERDTreeNodeDelimiters #' . g:NERDTreeNodeDelimiter . '# conceal containedin=ALL'
+    exec 'syn match NERDTreeNodeDelimiters #\%d' . char2nr(g:NERDTreeNodeDelimiter) . '# conceal containedin=ALL'
     setlocal conceallevel=3 concealcursor=nvic
 else
-    exec 'syn match NERDTreeNodeDelimiters #' . g:NERDTreeNodeDelimiter . '# containedin=ALL'
+    exec 'syn match NERDTreeNodeDelimiters #\%d' . char2nr(g:NERDTreeNodeDelimiter) . '# containedin=ALL'
     hi! link NERDTreeNodeDelimiters Ignore
 endif
 


### PR DESCRIPTION
Implements #912.

Change the default `NERDTreeNodeDelimiter` to `"\x07"`.
Update documentation in several area.