### PR TITLE
fixed root path error for windows

### DIFF
--- a/lib/nerdtree/path.vim
+++ b/lib/nerdtree/path.vim
@@ -15,7 +15,7 @@ function! s:Path.AbsolutePathFor(pathStr)
     let l:prependWorkingDir = 0
 
     if nerdtree#runningWindows()
-        let l:prependWorkingDir = a:pathStr !~# '^.:\(\\\|\/\)' && a:pathStr !~# '^\(\\\\\|\/\/\)'
+        let l:prependWorkingDir = a:pathStr !~# '^.:\(\\\|\/\)\?' && a:pathStr !~# '^\(\\\\\|\/\/\)'
     else
         let l:prependWorkingDir = a:pathStr !~# '^/'
     endif
@@ -23,7 +23,13 @@ function! s:Path.AbsolutePathFor(pathStr)
     let l:result = a:pathStr
 
     if l:prependWorkingDir
-        let l:result = getcwd() . s:Path.Slash() . a:pathStr
+        let l:result = getcwd()
+
+        if nerdtree#runningWindows() && (l:result[-1:] == '\' || l:result[-1:] == '/')
+            let l:result = l:result . a:pathStr
+        else
+            let l:result = l:result . s:Path.Slash() . a:pathStr
+        endif
     endif
 
     return l:result


### PR DESCRIPTION
there are two problems when change cwd to windows disk root like 'd:\\'

1. if set 'noshellslash', nerdtree can open, but will crash when open sub directory of 'd:\\', such as 'd:\\docs'
2. if set 'shellslash', nerdtree can be opened, and error message will echo `NERDTree: No bookmark or dirctory found for:`

the core point of these problems is that the function `getcwd()` result diffrent style for 'd:\\' and 'd:\\docs',
if set 'noshellslash', getcwd() return 'd:\\' with trailing slash and 'd:\\docs' without trailing slash.
if set 'shellslash', getcwd() return 'd:/' and 'd:/docs', the function s:Path.AbsolutePathFor() does not handle
these differences properly.
 
this pr maybe related to #860 #890 #895 