### PR TITLE
Add a NERDTreeMinimalMenu feature

### DIFF
--- a/doc/NERDTree.txt
+++ b/doc/NERDTree.txt
@@ -1126,15 +1126,13 @@ Default: 0
 
 This setting makes NERD tree use a smaller, more compact menu for adding,
 copying, deleting nodes. This menu fits on a single line so Vim doesn't need to
-scroll down to present it. Only the shortcut keys are displayed so this setting
-is recommended for users already familiar with the menu items.
+scroll down to present it. This setting is recommended for users already
+familiar with the menu items. It will look similar to this:
 
-It will look similar to this:
+  Menu: [ (a)dd ,m,d,r,o,q,c,l] (Use j/k/enter or shortcut):
 
-  Which action? (a*/m/d/r/o/q/c/l):
-
-An action can be selected with its shortcut key or by moving the position of the
-* character with NERDTreeMenuUp and NERDTreeMenuDown, then pressing return.
+An action can be selected with its shortcut key or with the NERDTreeMenuUp and
+NERDTreeMenuDown keys, then pressing enter.
 
 Use one of the following lines for this setting: >
     let NERDTreeMinimalMenu=0

--- a/doc/NERDTree.txt
+++ b/doc/NERDTree.txt
@@ -719,6 +719,9 @@ the NERD tree. These settings should be set in your vimrc, using `:let`.
 |NERDTreeMinimalUI|           Disables display of the 'Bookmarks' label and
                             'Press ? for help' text.
 
+|NERDTreeMinimalMenu|         Use a compact menu that fits on a single line
+                            for adding, copying, deleting, etc
+
 |NERDTreeCascadeSingleChildDir|
                             Collapses on the same line directories that have
                             only one child directory.
@@ -1115,6 +1118,28 @@ of the following lines for this setting: >
     let NERDTreeMinimalUI=0
     let NERDTreeMinimalUI=1
 <
+
+------------------------------------------------------------------------------
+                                                             *NERDTreeMinimalMenu*
+Values: 0 or 1
+Default: 0
+
+This setting makes NERD tree use a smaller, more compact menu for adding,
+copying, deleting nodes. This menu fits on a single line so Vim doesn't need to
+scroll down to present it. Only the shortcut keys are displayed so this setting
+is recommended for users already familiar with the menu items.
+
+It will look similar to this:
+
+  Which action? (a*/m/d/r/o/q/c/l):
+
+An action can be selected with its shortcut key or by moving the position of the
+* character with NERDTreeMenuUp and NERDTreeMenuDown, then pressing return.
+
+Use one of the following lines for this setting: >
+    let NERDTreeMinimalMenu=0
+    let NERDTreeMinimalMenu=1
+
 
 ------------------------------------------------------------------------------
                                                  *NERDTreeCascadeSingleChildDir*

--- a/lib/nerdtree/menu_controller.vim
+++ b/lib/nerdtree/menu_controller.vim
@@ -15,6 +15,11 @@ function! s:MenuController.New(menuItems)
     return newMenuController
 endfunction
 
+" FUNCTION: s:MenuController.isMinimal() {{{1
+function! s:MenuController.isMinimal()
+    return g:NERDTreeMinimalMenu
+endfunction
+
 " FUNCTION: MenuController.showMenu() {{{1
 " Enter the main loop of the NERDTree menu, prompting the user to select
 " a menu item.
@@ -49,16 +54,23 @@ endfunction
 
 "FUNCTION: MenuController._echoPrompt() {{{1
 function! s:MenuController._echoPrompt()
-    echo "NERDTree Menu. Use " . g:NERDTreeMenuDown . "/" . g:NERDTreeMenuUp . "/enter and the shortcuts indicated"
-    echo "=========================================================="
+    if self.isMinimal()
+        let shortcuts = map(copy(self.menuItems), "v:val['shortcut']")
+        let shortcuts[self.selection] .= "*"
 
-    for i in range(0, len(self.menuItems)-1)
-        if self.selection == i
-            echo "> " . self.menuItems[i].text
-        else
-            echo "  " . self.menuItems[i].text
-        endif
-    endfor
+        echo "Which action? (" . join(shortcuts, "/") . "): "
+    else
+        echo "NERDTree Menu. Use " . g:NERDTreeMenuDown . "/" . g:NERDTreeMenuUp . "/enter and the shortcuts indicated"
+        echo "=========================================================="
+
+        for i in range(0, len(self.menuItems)-1)
+            if self.selection == i
+                echo "> " . self.menuItems[i].text
+            else
+                echo "  " . self.menuItems[i].text
+            endif
+        endfor
+    endif
 endfunction
 
 "FUNCTION: MenuController._current(key) {{{1
@@ -129,7 +141,11 @@ endfunction
 "FUNCTION: MenuController._setCmdheight() {{{1
 "sets &cmdheight to whatever is needed to display the menu
 function! s:MenuController._setCmdheight()
-    let &cmdheight = len(self.menuItems) + 3
+    if self.isMinimal()
+        let &cmdheight = 1
+    else
+        let &cmdheight = len(self.menuItems) + 3
+    endif
 endfunction
 
 "FUNCTION: MenuController._saveOptions() {{{1

--- a/lib/nerdtree/menu_controller.vim
+++ b/lib/nerdtree/menu_controller.vim
@@ -54,14 +54,18 @@ endfunction
 
 "FUNCTION: MenuController._echoPrompt() {{{1
 function! s:MenuController._echoPrompt()
-    if self.isMinimal()
-        let shortcuts = map(copy(self.menuItems), "v:val['shortcut']")
-        let shortcuts[self.selection] .= "*"
+    let navHelp = "Use " . g:NERDTreeMenuDown . "/" . g:NERDTreeMenuUp . "/enter"
 
-        echo "Which action? (" . join(shortcuts, "/") . "): "
+    if self.isMinimal()
+        let selection = self.menuItems[self.selection].text
+
+        let shortcuts = map(copy(self.menuItems), "v:val['shortcut']")
+        let shortcuts[self.selection] = " " . split(selection)[0] . " "
+
+        echo "Menu: [" . join(shortcuts, ",") . "] (" . navHelp . " or shortcut): "
     else
-        echo "NERDTree Menu. Use " . g:NERDTreeMenuDown . "/" . g:NERDTreeMenuUp . "/enter and the shortcuts indicated"
-        echo "=========================================================="
+        echo "NERDTree Menu. " . navHelp . " . or the shortcuts indicated"
+        echo "========================================================="
 
         for i in range(0, len(self.menuItems)-1)
             if self.selection == i

--- a/nerdtree_plugin/fs_menu.vim
+++ b/nerdtree_plugin/fs_menu.vim
@@ -53,27 +53,36 @@ function! s:inputPrompt(action)
     if a:action == "add"
         let title = "Add a childnode"
         let info = "Enter the dir/file name to be created. Dirs end with a '/'"
+        let minimal = "Add node:"
 
     elseif a:action == "copy"
         let title = "Copy the current node"
         let info = "Enter the new path to copy the node to:"
+        let minimal = "Copy to:"
 
     elseif a:action == "delete"
         let title = "Delete the current node"
         let info = "Are you sure you wish to delete the node:"
+        let minimal = "Delete?"
 
     elseif a:action == "deleteNonEmpty"
         let title = "Delete the current node"
         let info =  "STOP! Directory is not empty! To delete, type 'yes'"
+        let minimal = "Delete directory?"
 
     elseif a:action == "move"
         let title = "Rename the current node"
         let info = "Enter the new path for the node:"
+        let minimal = "Move to:"
     endif
 
-    let divider = "=========================================================="
-
-    return title . "\n" . divider . "\n" . info . "\n"
+    if g:NERDTreeMenuController.isMinimal()
+        redraw! " Clear the menu
+        return minimal . " "
+    else
+        let divider = "=========================================================="
+        return title . "\n" . divider . "\n" . info . "\n"
+    end
 endfunction
 
 "FUNCTION: s:promptToDelBuffer(bufnum, msg){{{1
@@ -174,6 +183,8 @@ function! NERDTreeAddNode()
             call NERDTreeRender()
             call newTreeNode.putCursorHere(1, 0)
         endif
+
+        redraw!
     catch /^NERDTree/
         call nerdtree#echoWarning("Node Not Created.")
     endtry
@@ -222,7 +233,7 @@ function! NERDTreeMoveNode()
 
         call curNode.putCursorHere(1, 0)
 
-        redraw
+        redraw!
     catch /^NERDTree/
         call nerdtree#echoWarning("Node Not Renamed.")
     endtry
@@ -260,7 +271,7 @@ function! NERDTreeDeleteNode()
                 call s:promptToDelBuffer(bufnum, prompt)
             endif
 
-            redraw
+            redraw!
         catch /^NERDTree/
             call nerdtree#echoWarning("Could not remove node")
         endtry
@@ -350,7 +361,7 @@ function! NERDTreeCopyNode()
         call nerdtree#echo("Copy aborted.")
     endif
     let &shellslash = l:shellslash
-    redraw
+    redraw!
 endfunction
 
 " FUNCTION: NERDTreeQuickLook() {{{1

--- a/nerdtree_plugin/fs_menu.vim
+++ b/nerdtree_plugin/fs_menu.vim
@@ -44,6 +44,38 @@ else
     call NERDTreeAddMenuItem({'text': '(l)ist the current node', 'shortcut': 'l', 'callback': 'NERDTreeListNodeWin32'})
 endif
 
+"FUNCTION: s:inputPrompt(action){{{1
+"returns the string that should be prompted to the user for the given action
+"
+"Args:
+"action: the action that is being performed, e.g. 'delete'
+function! s:inputPrompt(action)
+    if a:action == "add"
+        let title = "Add a childnode"
+        let info = "Enter the dir/file name to be created. Dirs end with a '/'"
+
+    elseif a:action == "copy"
+        let title = "Copy the current node"
+        let info = "Enter the new path to copy the node to:"
+
+    elseif a:action == "delete"
+        let title = "Delete the current node"
+        let info = "Are you sure you wish to delete the node:"
+
+    elseif a:action == "deleteNonEmpty"
+        let title = "Delete the current node"
+        let info =  "STOP! Directory is not empty! To delete, type 'yes'"
+
+    elseif a:action == "move"
+        let title = "Rename the current node"
+        let info = "Enter the new path for the node:"
+    endif
+
+    let divider = "=========================================================="
+
+    return title . "\n" . divider . "\n" . info . "\n"
+endfunction
+
 "FUNCTION: s:promptToDelBuffer(bufnum, msg){{{1
 "prints out the given msg and, if the user responds by pushing 'y' then the
 "buffer with the given bufnum is deleted
@@ -114,14 +146,12 @@ function! s:renameBuffer(bufNum, newNodeName, isDirectory)
         " This happens when answering Cancel if confirmation is needed. Do nothing.
     endtry
 endfunction
+
 "FUNCTION: NERDTreeAddNode(){{{1
 function! NERDTreeAddNode()
     let curDirNode = g:NERDTreeDirNode.GetSelected()
-
-    let newNodeName = input("Add a childnode\n".
-                          \ "==========================================================\n".
-                          \ "Enter the dir/file name to be created. Dirs end with a '/'\n" .
-                          \ "", curDirNode.path.str() . g:NERDTreePath.Slash(), "file")
+    let prompt = s:inputPrompt("add")
+    let newNodeName = input(prompt, curDirNode.path.str() . g:NERDTreePath.Slash(), "file")
 
     if newNodeName ==# ''
         call nerdtree#echo("Node Creation Aborted.")
@@ -152,10 +182,8 @@ endfunction
 "FUNCTION: NERDTreeMoveNode(){{{1
 function! NERDTreeMoveNode()
     let curNode = g:NERDTreeFileNode.GetSelected()
-    let newNodePath = input("Rename the current node\n" .
-                          \ "==========================================================\n" .
-                          \ "Enter the new path for the node:                          \n" .
-                          \ "", curNode.path.str(), "file")
+    let prompt = s:inputPrompt("move")
+    let newNodePath = input(prompt, curNode.path.str(), "file")
 
     if newNodePath ==# ''
         call nerdtree#echo("Node Renaming Aborted.")
@@ -209,20 +237,15 @@ function! NERDTreeDeleteNode()
 
     if currentNode.path.isDirectory && ((currentNode.isOpen && currentNode.getChildCount() > 0) ||
                                       \ (len(currentNode._glob('*', 1)) > 0))
-        let choice =input("Delete the current node\n" .
-                         \ "==========================================================\n" .
-                         \ "STOP! Directory is not empty! To delete, type 'yes'\n" .
-                         \ "" . currentNode.path.str() . ": ")
+        let prompt = s:inputPrompt("deleteNonEmpty") . currentNode.path.str() . ": "
+        let choice = input(prompt)
         let confirmed = choice ==# 'yes'
     else
-        echo "Delete the current node\n" .
-           \ "==========================================================\n".
-           \ "Are you sure you wish to delete the node:\n" .
-           \ "" . currentNode.path.str() . " (yN):"
+        let prompt = s:inputPrompt("delete") . currentNode.path.str() . " (yN): "
+        echo prompt
         let choice = nr2char(getchar())
         let confirmed = choice ==# 'y'
     endif
-
 
     if confirmed
         try
@@ -292,10 +315,8 @@ function! NERDTreeCopyNode()
     let l:shellslash = &shellslash
     let &shellslash = 0
     let currentNode = g:NERDTreeFileNode.GetSelected()
-    let newNodePath = input("Copy the current node\n" .
-                          \ "==========================================================\n" .
-                          \ "Enter the new path to copy the node to:                   \n" .
-                          \ "", currentNode.path.str(), "file")
+    let prompt = s:inputPrompt("copy")
+    let newNodePath = input(prompt, currentNode.path.str(), "file")
 
     if newNodePath != ""
         "strip trailing slash

--- a/plugin/NERD_tree.vim
+++ b/plugin/NERD_tree.vim
@@ -51,6 +51,7 @@ call s:initVariable("g:NERDTreeSortHiddenFirst", 1)
 call s:initVariable("g:NERDTreeChDirMode", 0)
 call s:initVariable("g:NERDTreeCreatePrefix", "silent")
 call s:initVariable("g:NERDTreeMinimalUI", 0)
+call s:initVariable("g:NERDTreeMinimalMenu", 0)
 if !exists("g:NERDTreeIgnore")
     let g:NERDTreeIgnore = ['\~$']
 endif


### PR DESCRIPTION
Hello, thanks for maintaining a plugin I use all the time. ❤️ 

One thing I've wanted for a while is a more compact menu that reduces the amount of scrolling in Vim. I think a large portion of people who use NERDTree are already familiar with each of the menu items so this might be a nice addition to reduce noise.

Therefore, I've added a new configuration setting `NERDTreeMinimalMenu` for this. When this is set, a single-line menu is presented and the follow-up text for each action is presented as a single line, too.

Thanks


![menu](https://user-images.githubusercontent.com/892251/51482045-4b27bb00-1d8d-11e9-8d9b-7bff05679b93.gif)
