### PR TITLE
Escape a backslash so it can be used in a key mapping.

### DIFF
--- a/lib/nerdtree/key_map.vim
+++ b/lib/nerdtree/key_map.vim
@@ -51,6 +51,7 @@ function! s:KeyMap.bind()
     else
         let keymapInvokeString = self.key
     endif
+    let keymapInvokeString = escape(keymapInvokeString, '\')
 
     let premap = self.key == "<LeftRelease>" ? " <LeftRelease>" : " "
 


### PR DESCRIPTION
Fixes #735, #947.