### PR TITLE
Before copying, turn off &shellslash. Restore after copy is finished.

### DIFF
--- a/nerdtree_plugin/fs_menu.vim
+++ b/nerdtree_plugin/fs_menu.vim
@@ -283,6 +283,8 @@ endfunction
 
 " FUNCTION: NERDTreeCopyNode() {{{1
 function! NERDTreeCopyNode()
+    let l:shellslash = &shellslash
+    let &shellslash = 0
     let currentNode = g:NERDTreeFileNode.GetSelected()
     let newNodePath = input("Copy the current node\n" .
                           \ "==========================================================\n" .
@@ -320,6 +322,7 @@ function! NERDTreeCopyNode()
     else
         call nerdtree#echo("Copy aborted.")
     endif
+    let &shellslash = l:shellslash
     redraw
 endfunction
 


### PR DESCRIPTION
Fixes #776.