### PR TITLE
Preview bookmarks

### DIFF
--- a/autoload/nerdtree/ui_glue.vim
+++ b/autoload/nerdtree/ui_glue.vim
@@ -18,6 +18,7 @@ function! nerdtree#ui_glue#createDefaultBindings()
     call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapActivateNode, 'scope': "DirNode", 'callback': s."activateDirNode" })
     call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapActivateNode, 'scope': "FileNode", 'callback': s."activateFileNode" })
     call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapActivateNode, 'scope': "Bookmark", 'callback': s."activateBookmark" })
+    call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapPreview, 'scope': "Bookmark", 'callback': s."previewBookmark" })
     call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapActivateNode, 'scope': "all", 'callback': s."activateAll" })
 
     call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapOpenSplit, 'scope': "Node", 'callback': s."openHSplit" })
@@ -100,7 +101,7 @@ function! s:activateFileNode(node)
     call a:node.activate({'reuse': 'all', 'where': 'p'})
 endfunction
 
-"FUNCTION: s:activateBookmark() {{{1
+"FUNCTION: s:activateBookmark(bookmark) {{{1
 "handle the user activating a bookmark
 function! s:activateBookmark(bm)
     call a:bm.activate(b:NERDTree, !a:bm.path.isDirectory ? {'where': 'p'} : {})
@@ -493,6 +494,15 @@ function! s:openNodeRecursively(node)
     call b:NERDTree.render()
     redraw
     call nerdtree#echo("Recursively opening node. Please wait... DONE")
+endfunction
+
+" FUNCTION: s:previewBookmark(bookmark) {{{1
+function! s:previewBookmark(bookmark)
+    if a:bookmark.path.isDirectory
+        execute 'NERDTreeFind '.a:bookmark.path.str()
+    else
+        call a:bookmark.activate(b:NERDTree, {'stay': 1, 'where': 'p', 'keepopen': 1})
+    endif
 endfunction
 
 "FUNCTION: s:previewNodeCurrent(node) {{{1

--- a/doc/NERDTree.txt
+++ b/doc/NERDTree.txt
@@ -240,6 +240,7 @@ Key      Description                                                  help-tag~
 
 o........Open files, directories and bookmarks......................|NERDTree-o|
 go.......Open selected file, but leave cursor in the NERDTree......|NERDTree-go|
+         Open selected bookmark dir in current NERDTree
 t........Open selected node/bookmark in a new tab...................|NERDTree-t|
 T........Same as 't' but keep the focus on the current tab..........|NERDTree-T|
 i........Open selected file in a split window.......................|NERDTree-i|
@@ -305,8 +306,12 @@ Default key: go
 Map setting: NERDTreeMapPreview
 Applies to: files.
 
-If a file node is selected, it is opened in the previous window, but the
-cursor does not move.
+If a file node or a bookmark that links to a file is selected, it is opened in
+the previous window, but the cursor does not move.
+
+If a bookmark that links to a directory is selected, that directory is found
+in the current NERDTree. If the directory couldn't be found, a new NERDTree is
+created.
 
 The default key combo for this mapping is "g" + NERDTreeMapActivateNode (see
 |NERDTree-o|).

--- a/lib/nerdtree/ui.vim
+++ b/lib/nerdtree/ui.vim
@@ -62,6 +62,8 @@ function! s:UI._dumpHelp()
         let help .= "\" Bookmark table mappings~\n"
         let help .= "\" double-click,\n"
         let help .= "\" ". g:NERDTreeMapActivateNode .": open bookmark\n"
+        let help .= "\" ". g:NERDTreeMapPreview .": preview file\n"
+        let help .= "\" ". g:NERDTreeMapPreview .": find dir in tree\n"
         let help .= "\" ". g:NERDTreeMapOpenInTab.": open in new tab\n"
         let help .= "\" ". g:NERDTreeMapOpenInTabSilent .": open in new tab silently\n"
         let help .= "\" ". g:NERDTreeMapDeleteBookmark .": delete bookmark\n"


### PR DESCRIPTION
Closes #271 

The preview key (`go` by default) will now work on bookmarks. Bookmarks that are files will be previewed just like regular file nodes. Bookmarks that are directories will be located using the `NERDTreeFind` command, preserving the current NERDTree root directory if possible.