### PR TITLE
On Windows, do a case-insensitive comparison of paths.

### DIFF
--- a/lib/nerdtree/path.vim
+++ b/lib/nerdtree/path.vim
@@ -564,7 +564,11 @@ endfunction
 " Args:
 " path: the other path obj to compare this with
 function! s:Path.equals(path)
-    return self.str() ==# a:path.str()
+    if nerdtree#runningWindows()
+        return self.str() ==? a:path.str()
+    else
+        return self.str() ==# a:path.str()
+    endif
 endfunction
 
 " FUNCTION: Path.New(pathStr) {{{1


### PR DESCRIPTION
Fixes #951 

I didn't investigate why or if it's related to `NERDTreeChDirMode=2`, but I discovered this comparison was forcing case sensitivity, when on Windows it needn't be.