### PR TITLE
Fix flicker when opening child nodes

### DIFF
--- a/autoload/nerdtree/ui_glue.vim
+++ b/autoload/nerdtree/ui_glue.vim
@@ -492,7 +492,7 @@ function! s:openNodeRecursively(node)
     call nerdtree#echo("Recursively opening node. Please wait...")
     call a:node.openRecursively()
     call b:NERDTree.render()
-    redraw!
+    redraw
 endfunction
 
 " FUNCTION: s:previewBookmark(bookmark) {{{1
@@ -543,7 +543,7 @@ function! s:refreshRoot()
     call nerdtree#exec(g:NERDTree.GetWinNum() . "wincmd w")
     call b:NERDTree.root.refresh()
     call b:NERDTree.render()
-    redraw!
+    redraw
     call nerdtree#exec(l:curWin . "wincmd w")
 endfunction
 
@@ -558,7 +558,7 @@ function! s:refreshCurrent(node)
     call nerdtree#echo("Refreshing node. This could take a while...")
     call node.refresh()
     call b:NERDTree.render()
-    redraw!
+    redraw
 endfunction
 
 " FUNCTION: nerdtree#ui_glue#setupCommands() {{{1

--- a/lib/nerdtree/tree_dir_node.vim
+++ b/lib/nerdtree/tree_dir_node.vim
@@ -432,7 +432,7 @@ function! s:TreeDirNode._initChildren(silent)
 
     call self.sortChildren()
 
-    redraw!
+    redraw
 
     if invalidFilesFound
         call nerdtree#echoWarning(invalidFilesFound . " file(s) could not be loaded into the NERD tree")


### PR DESCRIPTION
Clearing the screen before redrawing seems to cause a nasty flicker for me. I'm using the urxvt terminal on an Arch Linux. 

![nerdtree_demo](https://user-images.githubusercontent.com/124255/55666898-bd248200-585d-11e9-85ba-262e815c451b.gif)

I don't see the same effect on gnome-terminal, so this might be a specific problem to xterm-like minimal terminals. If there's a reason to use `redraw!` (to avoid some issue I don't know about), maybe another setting can be introduced particularly for us old-schoolers?