### PR TITLE
Change minimum vim

### DIFF
--- a/autoload/nerdtree.vim
+++ b/autoload/nerdtree.vim
@@ -10,6 +10,29 @@ endfunction
 " SECTION: General Functions {{{1
 "============================================================
 
+"FUNCTION: nerdtree#and(x,y) {{{2
+" Implements and() function for Vim <= 7.2
+function! nerdtree#and(x,y)
+    if exists("*and")
+        return and(a:x, a:y)
+    else
+        let l:x = a:x
+        let l:y = a:y
+        let l:n = 0
+        let l:result = 0
+        while l:x > 0 && l:y > 0
+            if (l:x % 2) && (l:y % 2)
+                let l:result += float2nr(pow(2, l:n))
+            endif
+            echomsg l:x . ", " . l:y . " => " l:result
+            let l:x = float2nr(l:x / 2)
+            let l:y = float2nr(l:y / 2)
+            let l:n += 1
+        endwhile
+        return l:result
+    endif
+endfunction
+
 "FUNCTION: nerdtree#checkForBrowse(dir) {{{2
 "inits a window tree in the current buffer if appropriate
 function! nerdtree#checkForBrowse(dir)

--- a/lib/nerdtree/bookmark.vim
+++ b/lib/nerdtree/bookmark.vim
@@ -256,7 +256,7 @@ endfunction
 function! s:Bookmark.open(nerdtree, ...)
     let opts = a:0 ? a:1 : {}
 
-    if and(g:NERDTreeQuitOnOpen,2)
+    if nerdtree#and(g:NERDTreeQuitOnOpen,2)
         call a:nerdtree.ui.toggleShowBookmarks()
     endif
 

--- a/lib/nerdtree/nerdtree.vim
+++ b/lib/nerdtree/nerdtree.vim
@@ -66,7 +66,7 @@ endfunction
 "FUNCTION: s:NERDTree.CloseIfQuitOnOpen() {{{1
 "Closes the NERD tree window if the close on open option is set
 function! s:NERDTree.CloseIfQuitOnOpen()
-    if and(g:NERDTreeQuitOnOpen,1) && s:NERDTree.IsOpen()
+    if nerdtree#and(g:NERDTreeQuitOnOpen,1) && s:NERDTree.IsOpen()
         call s:NERDTree.Close()
     endif
 endfunction

--- a/plugin/NERD_tree.vim
+++ b/plugin/NERD_tree.vim
@@ -14,8 +14,8 @@
 if exists("loaded_nerd_tree")
     finish
 endif
-if v:version < 700
-    echoerr "NERDTree: this plugin requires vim >= 7. DOWNLOAD IT! You'll thank me later!"
+if v:version < 730
+    echoerr "NERDTree: this plugin requires vim >= 7.3. DOWNLOAD IT! You'll thank me later!"
     finish
 endif
 let loaded_nerd_tree = 1


### PR DESCRIPTION
Closes #973.

I wrote a workaround version of `and()`, so we don't need to make 7.4 the minimum.