### PR TITLE
Fix minimum vim compare

### DIFF
--- a/plugin/NERD_tree.vim
+++ b/plugin/NERD_tree.vim
@@ -14,7 +14,7 @@
 if exists("loaded_nerd_tree")
     finish
 endif
-if v:version < 730
+if v:version < 703
     echoerr "NERDTree: this plugin requires vim >= 7.3. DOWNLOAD IT! You'll thank me later!"
     finish
 endif


### PR DESCRIPTION
Actually, v:version of vim 7.3 is 703, NOT 730. So,
'if v:version < 730' should be 'if v:version < 703'.

Signed-off-by: Trol <jiaoxiaodong@xiaomi.com>