### PR TITLE
Change version check to look for 703 not 730

### DIFF
--- a/plugin/NERD_tree.vim
+++ b/plugin/NERD_tree.vim
@@ -14,7 +14,7 @@
 if exists("loaded_nerd_tree")
     finish
 endif
-if v:version < 730
+if v:version < 703
     echoerr "NERDTree: this plugin requires vim >= 7.3. DOWNLOAD IT! You'll thank me later!"
     finish
 endif


### PR DESCRIPTION
My Vim reports as 704 through `:echo v:version` when it is version 7.4, so this number should be 703 not 730.

I don't have an older version of vim to verify this behaviour is consistent across versions, though