### PR TITLE
Enable root refresh on "vim ." a different way than #999.

### DIFF
--- a/lib/nerdtree/creator.vim
+++ b/lib/nerdtree/creator.vim
@@ -96,8 +96,7 @@ function! s:Creator.createWindowTree(dir)
 
     "we need a unique name for each window tree buffer to ensure they are
     "all independent
-    let t:NERDTreeBufName = self._nextBufferName()
-    exec g:NERDTreeCreatePrefix . " edit " . t:NERDTreeBufName
+    exec g:NERDTreeCreatePrefix . " edit " . self._nextBufferName()
 
     call self._createNERDTree(path, "window")
     let b:NERDTree._previousBuf = bufnr(previousBuf)

--- a/lib/nerdtree/nerdtree.vim
+++ b/lib/nerdtree/nerdtree.vim
@@ -153,7 +153,7 @@ endfunction
 
 "FUNCTION: s:NERDTree.IsOpen() {{{1
 function! s:NERDTree.IsOpen()
-    return s:NERDTree.GetWinNum() != -1 || bufname('%') =~# '^NERD_tree_\d\+$'
+    return s:NERDTree.GetWinNum() != -1 || bufname('%') =~# '^' . g:NERDTreeCreator.BufNamePrefix() . '\d\+$'
 endfunction
 
 "FUNCTION: s:NERDTree.isTabTree() {{{1

--- a/lib/nerdtree/nerdtree.vim
+++ b/lib/nerdtree/nerdtree.vim
@@ -153,7 +153,7 @@ endfunction
 
 "FUNCTION: s:NERDTree.IsOpen() {{{1
 function! s:NERDTree.IsOpen()
-    return s:NERDTree.GetWinNum() != -1
+    return s:NERDTree.GetWinNum() != -1 || bufname('%') =~# '^NERD_tree_\d\+$'
 endfunction
 
 "FUNCTION: s:NERDTree.isTabTree() {{{1


### PR DESCRIPTION
Fixes #1000.
Reverts #999.
Fixes https://github.com/scrooloose/nerdtree/pull/897#issuecomment-497551904 a different way.

Instead of assigning a value to t:NERDTreeBufName for a window tree,
which is used to determine if NERDTree is open, simply also look at the
current buffer's name to see if it matches the NERDTree pattern.