### PR TITLE
Expand functionality of <CR> mapping

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -23,7 +23,7 @@ After reading, and before submitting your issue, please remove this introductory
 #### Environment (for bug reports)
 - [ ] Operating System: 
 - [ ] Vim/Neovim version `:version`: 
-- [ ] NERDTree version `git rev-parse --short HEAD`: 
+- [ ] NERDTree version `:echo nerdtree#version(0)` or `git rev-parse --short HEAD`: 
 - [ ] A link to my [vimrc](), or
 - [ ] vimrc settings
     - [ ] NERDTree variables

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,22 +1,21 @@
-<!-- Enter the issue number this PR addresses below. If none, remove the line. -->
 ### Description of Changes
+Closes #  <!-- Issue number this PR addresses. If none, remove this line. -->
 
-Closes #
 
 ---
 ### New Version Info
 
 - [ ] Derive a new version number. Increment the:
-    - [ ] `MAJOR` version when you make incompatible API changes,
-    - [ ] `MINOR` version when you add functionality in a backwards-compatible manner, and
-    - [ ] `PATCH` version when you make backwards-compatible bug fixes.
-- [ ] Update version number in [autoload/nerdtree.vim](https://github.com/scrooloose/nerdtree/blob/master/autoload/nerdtree.vim#L7)
-- [ ] Update the ChangeLog, following this format/example:
+    - [ ] `MAJOR` version when you make incompatible API changes
+    - [ ] `MINOR` version when you add functionality in a backwards-compatible manner
+    - [ ] `PATCH` version when you make backwards-compatible bug fixes
+- [ ] Update version number in [autoload/nerdtree.vim](https://github.com/scrooloose/nerdtree/blob/master/autoload/nerdtree.vim#L7).
+- [ ] Update [CHANGELOG.md](https://github.com/scrooloose/nerdtree/blob/master/CHANGELOG.md), following this format/example:
     ```
-    MAJOR.MINOR...
+    #### MAJOR.MINOR...
     - **.PATCH**: PR Title (Author) #PR Number
 
-    ### 5.1...
+    #### 5.1...
     - **.1**: Update Changelog and create PR Template (PhilRunninger) #1007
     - **.0**: Too many changes for one patch...
     ```

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,7 +9,6 @@ Closes #  <!-- Issue number this PR addresses. If none, remove this line. -->
     - [ ] `MAJOR` version when you make incompatible API changes
     - [ ] `MINOR` version when you add functionality in a backwards-compatible manner
     - [ ] `PATCH` version when you make backwards-compatible bug fixes
-- [ ] Update version number in [autoload/nerdtree.vim](https://github.com/scrooloose/nerdtree/blob/master/autoload/nerdtree.vim#L7).
 - [ ] Update [CHANGELOG.md](https://github.com/scrooloose/nerdtree/blob/master/CHANGELOG.md), following this format/example:
     ```
     #### MAJOR.MINOR...

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,30 +141,7 @@
 - make the root note render prettier by truncating it at a path slash (gcmt)
 - remove NERDChristmasTree option - its always christmas now
 - add "cascade" open and closing for dirs containing only another single dir. See :help NERDTreeCascadeOpenSingleChildDir (pendulm)
-- Many other fixes, doc updates and contributions from:
-    - @actionshrimp
-    - @SchDen
-    - @egalpin
-    - @cperl82 - many small fixes
-    - @toiffel
-    - @WoLpH
-    - @handcraftedbits
-    - @devmanhinton
-    - @xiaodili
-    - @zhangoose
-    - @gastropoda
-    - @mixvin
-    - @alvan
-    - @lucascaton
-    - @kelaban
-    - @shanesmith
-    - @staeff
-    - @pendulm
-    - @stephenprater
-    - @franksort
-    - @agrussellknives
-    - @AndrewRadev
-    - @Twinside
+- Many other fixes, doc updates and contributions from: **actionshrimp**, **agrussellknives**, **alvan**, **AndrewRadev**, **cperl82** (*many small fixes*), **devmanhinton**, **egalpin**, **franksort**, **gastropoda**, **handcraftedbits**, **kelaban**, **lucascaton**, **mixvin**, **pendulm**, **SchDen**, **shanesmith**, **staeff**, **stephenprater**, **toiffel**, **Twinside**, **WoLpH**, **xiaodili**, **zhangoose**
 
 #### 4.2.0
 - Add NERDTreeDirArrows option to make the UI use pretty arrow chars instead of the old +~| chars to define the tree structure (sickill)
@@ -174,45 +151,34 @@
 - tweak the behaviour of :NERDTreeFind - see :help :NERDTreeFind for the new behaviour (benjamingeiger)
 - if no name is given to :Bookmark, make it default to the name of the target file/dir (minyoung)
 - use `file` completion when doing copying, create, and move operations (EvanDotPro)
-- lots of misc bug fixes from:
-    - @paddyoloughlin
-    - @sdewald
-    - @camthompson
-    - @Vitaly
-    - @Bogdanov
-    - @AndrewRadev
-    - @mathias
-    - @scottstvnsn
-    - @kml
-    - @wycats
-    - me RAWR!
+- lots of misc bug fixes from: **AndrewRadev**, **Bogdanov**, **camthompson**, **kml**, **mathias**, **paddyoloughlin**, **scottstvnsn**, **sdewald**, **Vitaly**, **wycats**, me RAWR!
 
 #### 4.1.0
 - features:
-    - NERDTreeFind to reveal the node for the current buffer in the tree, see `|NERDTreeFind|`. This effectively merges the FindInNERDTree plugin (by Doug McInnes) into the script.
-    - make NERDTreeQuitOnOpen apply to the t/T keymaps too. Thanks to Stefan Ritter and Rémi Prévost.
-    - truncate the root node if wider than the tree window. Thanks to Victor Gonzalez.
+    - NERDTreeFind to reveal the node for the current buffer in the tree, see `|NERDTreeFind|`. This effectively merges the FindInNERDTree plugin (by **Doug McInnes**) into the script.
+    - make NERDTreeQuitOnOpen apply to the t/T keymaps too. Thanks to **Stefan Ritter** and **Rémi Prévost**.
+    - truncate the root node if wider than the tree window. Thanks to **Victor Gonzalez**.
 
 - bugfixes:
     - really fix window state restoring
-    - fix some win32 path escaping issues. Thanks to Stephan Baumeister, Ricky, jfilip1024, and Chris Chambers
+    - fix some win32 path escaping issues. Thanks to **Stephan Baumeister**, **Ricky**, **jfilip1024**, and **Chris Chambers**.
 
 #### 4.0.0
 - add a new programmable menu system (see `:help NERDTreeMenu`).
 - add new APIs to add menus/menu-items to the menu system as well as custom key mappings to the NERD tree buffer (see `:help NERDTreeAPI`).
 - removed the old API functions
 - added a mapping to maximize/restore the size of nerd tree window, thanks to Guillaume Duranceau for the patch. See :help NERDTree-A for details.
-- fix a bug where secondary nerd trees (netrw hijacked trees) and NERDTreeQuitOnOpen didnt play nicely, thanks to Curtis Harvey.
-- fix a bug where the script ignored directories whose name ended in a dot, thanks to Aggelos Orfanakos for the patch.
-- fix a bug when using the x mapping on the tree root, thanks to Bryan Venteicher for the patch.
-- fix a bug where the cursor position/window size of the nerd tree buffer wasnt being stored on closing the window, thanks to Richard Hart.
+- fix a bug where secondary nerd trees (netrw hijacked trees) and NERDTreeQuitOnOpen didnt play nicely, thanks to **Curtis Harvey**.
+- fix a bug where the script ignored directories whose name ended in a dot, thanks to **Aggelos Orfanakos** for the patch.
+- fix a bug when using the x mapping on the tree root, thanks to **Bryan Venteicher** for the patch.
+- fix a bug where the cursor position/window size of the nerd tree buffer wasnt being stored on closing the window, thanks to **Richard Hart**.
 - fix a bug where NERDTreeMirror would mirror the wrong tree
 
 #### 3.1.1
-- fix a bug where a non-listed no-name buffer was getting created every time the tree windows was created, thanks to Derek Wyatt and owen1
+- fix a bug where a non-listed no-name buffer was getting created every time the tree windows was created, thanks to **Derek Wyatt** and **owen1**
 - make `<CR>` behave the same as the `o` mapping
-- some helptag fixes in the doc, thanks @strull
-- fix a bug when using `:set nohidden` and opening a file where the previous buf was modified. Thanks @iElectric
+- some helptag fixes in the doc, thanks **strull**.
+- fix a bug when using `:set nohidden` and opening a file where the previous buf was modified. Thanks **iElectric**.
 - other minor fixes
 
 #### 3.1.0
@@ -220,19 +186,19 @@
     - add mappings to open files in a vsplit, see `:help NERDTree-s` and `:help NERDTree-gs`
     - make the statusline for the nerd tree window default to something hopefully more useful. See `:help 'NERDTreeStatusline'`
 - Bugfixes:
-    - make the hijack netrw functionality work when vim is started with `vim <some dir>` (thanks to Alf Mikula for the patch).
-    - fix a bug where the CWD wasnt being changed for some operations even when NERDTreeChDirMode==2 (thanks to Lucas S. Buchala)
-    - add -bar to all the nerd tree :commands so they can chain with other :commands (thanks to tpope)
-    - fix bugs when ignorecase was set (thanks to nach)
-    - fix a bug with the relative path code (thanks to nach)
-    - fix a bug where doing a `:cd` would cause `:NERDTreeToggle` to fail (thanks nach)
+    - make the hijack netrw functionality work when vim is started with `vim <some dir>` (thanks to **Alf Mikula** for the patch).
+    - fix a bug where the CWD wasnt being changed for some operations even when NERDTreeChDirMode==2 (thanks to **Lucas S. Buchala**)
+    - add -bar to all the nerd tree :commands so they can chain with other :commands (thanks to **tpope**)
+    - fix bugs when ignorecase was set (thanks to **nach**)
+    - fix a bug with the relative path code (thanks to **nach**)
+    - fix a bug where doing a `:cd` would cause `:NERDTreeToggle` to fail (thanks **nach**)
 
 
 #### 3.0.1
 - Bugfixes:
     - fix bugs with :NERDTreeToggle and :NERDTreeMirror when `'hidden'` was not set
-    - fix a bug where `:NERDTree <path>` would fail if `<path>` was relative and didnt start with a `./` or `../`  Thanks to James Kanze.
-    - make the `q` mapping work with secondary (`:e <dir>`  style) trees, thanks to jamessan
+    - fix a bug where `:NERDTree <path>` would fail if `<path>` was relative and didnt start with a `./` or `../`  Thanks to **James Kanze**.
+    - make the `q` mapping work with secondary (`:e <dir>`  style) trees, thanks to **jamessan**
     - fix a bunch of small bugs with secondary trees
 - More insane refactoring.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Change Log
 
+### 5.2...
+- **`.0**: Expand functionality of <CR> mapping. (PhilRunninger) #1011
 ### 5.1...
 - **`.3`**: Remove @mentions from PR template and change log. They weren't working. (PhilRunninger) #1009
 - **`.2`**: Fix NERDTree opening with the wrong size. (PhilRunninger) #1008

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Change Log
 
 ### 5.2...
-- **`.0**: Expand functionality of <CR> mapping. (PhilRunninger) #1011
+- **`.0`**: Expand functionality of <CR> mapping. (PhilRunninger) #1011
 ### 5.1...
 - **`.3`**: Remove @mentions from PR template and change log. They weren't working. (PhilRunninger) #1009
 - **`.2`**: Fix NERDTree opening with the wrong size. (PhilRunninger) #1008

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,12 @@
 # Change Log
 
-### 5.2...
-- **`.0`**: Expand functionality of <CR> mapping. (PhilRunninger) #1011
-### 5.1...
-- **`.3`**: Remove @mentions from PR template and change log. They weren't working. (PhilRunninger) #1009
-- **`.2`**: Fix NERDTree opening with the wrong size. (PhilRunninger) #1008
-- **`.1`**: Update Changelog and create PR Template (PhilRunninger) #1007
-- **`.0`**: Too many changes for one patch...
+#### 5.2...
+- **.0**: Expand functionality of `<CR>` mapping. (PhilRunninger) #1011
+#### 5.1...
+- **.3**: Remove @mentions from PR template and change log. They weren't working. (PhilRunninger) #1009
+- **.2**: Fix NERDTree opening with the wrong size. (PhilRunninger) #1008
+- **.1**: Update Changelog and create PR Template (PhilRunninger) #1007
+- **.0**: Too many changes for one patch...
     - Refresh a dir_node if the file wasn't found in it, and look once more. (PhilRunninger) #1005
     - Add a "copy path to clipboard" menu option (PhilRunninger) #1002
     - Enable root refresh on "vim ." a different way than #999. (PhilRunninger) #1001
@@ -124,7 +124,7 @@
     - On windows default to + and ~ for expand/collapse directory symbols.
     - Lots more refactoring. Move a bunch of b: level vars into b:NERDTree and friends.
 
-### 5.0.0
+#### 5.0.0
 - Refactor the code significantly:
     * Break the classes out into their own files.
     * Make the majority of the code OO - previously large parts were effectively a tangle of "global" methods.
@@ -166,7 +166,7 @@
     - @AndrewRadev
     - @Twinside
 
-### 4.2.0
+#### 4.2.0
 - Add NERDTreeDirArrows option to make the UI use pretty arrow chars instead of the old +~| chars to define the tree structure (sickill)
 - shift the syntax highlighting out into its own syntax file (gnap)
 - add some mac specific options to the filesystem menu - for macvim only (andersonfreitas)
@@ -187,7 +187,7 @@
     - @wycats
     - me RAWR!
 
-### 4.1.0
+#### 4.1.0
 - features:
     - NERDTreeFind to reveal the node for the current buffer in the tree, see `|NERDTreeFind|`. This effectively merges the FindInNERDTree plugin (by Doug McInnes) into the script.
     - make NERDTreeQuitOnOpen apply to the t/T keymaps too. Thanks to Stefan Ritter and Rémi Prévost.
@@ -197,7 +197,7 @@
     - really fix window state restoring
     - fix some win32 path escaping issues. Thanks to Stephan Baumeister, Ricky, jfilip1024, and Chris Chambers
 
-### 4.0.0
+#### 4.0.0
 - add a new programmable menu system (see `:help NERDTreeMenu`).
 - add new APIs to add menus/menu-items to the menu system as well as custom key mappings to the NERD tree buffer (see `:help NERDTreeAPI`).
 - removed the old API functions
@@ -208,14 +208,14 @@
 - fix a bug where the cursor position/window size of the nerd tree buffer wasnt being stored on closing the window, thanks to Richard Hart.
 - fix a bug where NERDTreeMirror would mirror the wrong tree
 
-### 3.1.1
+#### 3.1.1
 - fix a bug where a non-listed no-name buffer was getting created every time the tree windows was created, thanks to Derek Wyatt and owen1
 - make `<CR>` behave the same as the `o` mapping
 - some helptag fixes in the doc, thanks @strull
 - fix a bug when using `:set nohidden` and opening a file where the previous buf was modified. Thanks @iElectric
 - other minor fixes
 
-### 3.1.0
+#### 3.1.0
 - New features:
     - add mappings to open files in a vsplit, see `:help NERDTree-s` and `:help NERDTree-gs`
     - make the statusline for the nerd tree window default to something hopefully more useful. See `:help 'NERDTreeStatusline'`
@@ -228,7 +228,7 @@
     - fix a bug where doing a `:cd` would cause `:NERDTreeToggle` to fail (thanks nach)
 
 
-### 3.0.1
+#### 3.0.1
 - Bugfixes:
     - fix bugs with :NERDTreeToggle and :NERDTreeMirror when `'hidden'` was not set
     - fix a bug where `:NERDTree <path>` would fail if `<path>` was relative and didnt start with a `./` or `../`  Thanks to James Kanze.
@@ -236,7 +236,7 @@
     - fix a bunch of small bugs with secondary trees
 - More insane refactoring.
 
-### 3.0.0
+#### 3.0.0
 - hijack netrw so that doing an `:edit <directory>`  will put a NERD tree in the window rather than a netrw browser. See :help 'NERDTreeHijackNetrw'
 - allow sharing of trees across tabs, see `:help :NERDTreeMirror`
 - remove "top" and "bottom" as valid settings for NERDTreeWinPos

--- a/autoload/nerdtree.vim
+++ b/autoload/nerdtree.vim
@@ -4,7 +4,7 @@ endif
 let g:loaded_nerdtree_autoload = 1
 
 function! nerdtree#version()
-    return '5.1.3'
+    return '5.2.0'
 endfunction
 
 " SECTION: General Functions {{{1

--- a/autoload/nerdtree.vim
+++ b/autoload/nerdtree.vim
@@ -3,8 +3,18 @@ if exists("g:loaded_nerdtree_autoload")
 endif
 let g:loaded_nerdtree_autoload = 1
 
-function! nerdtree#version()
-    return '5.2.0'
+function! nerdtree#version(...)
+    let l:changelog = readfile(expand("<sfile>:p:h")."/CHANGELOG.md")
+    let l:line = 0
+    while l:line <= len(l:changelog)
+        if l:changelog[l:line] =~ '\d\+\.\d\+'
+            let l:text = substitute(l:changelog[l:line], '.*\(\d\+.\d\+\).*', '\1', '')
+            let l:text .= substitute(l:changelog[l:line+1], '^.\{-}\(\.\d\+\).\{-}:\(.*\)', a:0>0 ? '\1:\2' : '\1', '')
+            break
+        endif
+        let l:line += 1
+    endwhile
+    return l:text
 endfunction
 
 " SECTION: General Functions {{{1

--- a/autoload/nerdtree.vim
+++ b/autoload/nerdtree.vim
@@ -5,6 +5,7 @@ let g:loaded_nerdtree_autoload = 1
 
 function! nerdtree#version(...)
     let l:changelog = readfile(expand("<sfile>:p:h")."/CHANGELOG.md")
+    let l:text = 'Unknown'
     let l:line = 0
     while l:line <= len(l:changelog)
         if l:changelog[l:line] =~ '\d\+\.\d\+'

--- a/autoload/nerdtree/ui_glue.vim
+++ b/autoload/nerdtree/ui_glue.vim
@@ -14,6 +14,9 @@ function! nerdtree#ui_glue#createDefaultBindings()
     call NERDTreeAddKeyMap({ 'key': '<2-LeftMouse>', 'scope': "Bookmark", 'callback': s."activateBookmark" })
     call NERDTreeAddKeyMap({ 'key': '<2-LeftMouse>', 'scope': "all", 'callback': s."activateAll" })
 
+    call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapUserDefOpen, 'scope':'FileNode', 'callback': s."defaultOpenFile"})
+    call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapUserDefOpen, 'scope':'DirNode', 'callback': s."defaultOpenDir"})
+    call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapUserDefOpen, 'scope':'Bookmark', 'callback': s."defaultOpenBookmark"})
 
     call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapActivateNode, 'scope': "DirNode", 'callback': s."activateDirNode" })
     call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapActivateNode, 'scope': "FileNode", 'callback': s."activateFileNode" })
@@ -76,6 +79,24 @@ endfunction
 "SECTION: Interface bindings {{{1
 "============================================================
 
+"FUNCTION: s:defaultOpenFile() {{{1
+" Open file node with the "default" key, initially <CR>.
+function! s:defaultOpenFile(node)
+    call a:node.activate(g:NERDTreeUserDefOpenArgs)
+endfunction
+
+"FUNCTION: s:defaultOpenDir() {{{1
+" Open directory node with the "default" key, initially <CR>.
+function! s:defaultOpenDir(node)
+    call s:activateDirNode(a:node, g:NERDTreeUserDefOpenArgs)
+endfunction
+
+"FUNCTION: s:defaultOpenBookmark() {{{1
+" Open bookmark node with the "default" key, initially <CR>.
+function! s:defaultOpenBookmark(node)
+    call a:node.activate(b:NERDTree, g:NERDTreeUserDefOpenArgs)
+endfunction
+
 "FUNCTION: s:activateAll() {{{1
 "handle the user activating the updir line
 function! s:activateAll()
@@ -84,15 +105,16 @@ function! s:activateAll()
     endif
 endfunction
 
-" FUNCTION: s:activateDirNode(directoryNode) {{{1
-function! s:activateDirNode(directoryNode)
+" FUNCTION: s:activateDirNode(directoryNode, options) {{{1
+" Open a directory with optional options
+function! s:activateDirNode(directoryNode, ...)
 
     if a:directoryNode.isRoot() && a:directoryNode.isOpen
         call nerdtree#echo('cannot close tree root')
         return
     endif
 
-    call a:directoryNode.activate()
+    call a:directoryNode.activate((a:0 > 0) ? a:1 : {})
 endfunction
 
 "FUNCTION: s:activateFileNode() {{{1

--- a/autoload/nerdtree/ui_glue.vim
+++ b/autoload/nerdtree/ui_glue.vim
@@ -14,9 +14,9 @@ function! nerdtree#ui_glue#createDefaultBindings()
     call NERDTreeAddKeyMap({ 'key': '<2-LeftMouse>', 'scope': "Bookmark", 'callback': s."activateBookmark" })
     call NERDTreeAddKeyMap({ 'key': '<2-LeftMouse>', 'scope': "all", 'callback': s."activateAll" })
 
-    call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapCustomOpen, 'scope':'FileNode', 'callback': s."defaultOpenFile"})
-    call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapCustomOpen, 'scope':'DirNode', 'callback': s."defaultOpenDir"})
-    call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapCustomOpen, 'scope':'Bookmark', 'callback': s."defaultOpenBookmark"})
+    call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapCustomOpen, 'scope':'FileNode', 'callback': s."customOpenFile"})
+    call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapCustomOpen, 'scope':'DirNode', 'callback': s."customOpenDir"})
+    call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapCustomOpen, 'scope':'Bookmark', 'callback': s."customOpenBookmark"})
 
     call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapActivateNode, 'scope': "DirNode", 'callback': s."activateDirNode" })
     call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapActivateNode, 'scope': "FileNode", 'callback': s."activateFileNode" })
@@ -79,21 +79,21 @@ endfunction
 "SECTION: Interface bindings {{{1
 "============================================================
 
-"FUNCTION: s:defaultOpenFile() {{{1
-" Open file node with the "default" key, initially <CR>.
-function! s:defaultOpenFile(node)
+"FUNCTION: s:customOpenFile() {{{1
+" Open file node with the "custom" key, initially <CR>.
+function! s:customOpenFile(node)
     call a:node.activate(g:NERDTreeCustomOpenArgs)
 endfunction
 
-"FUNCTION: s:defaultOpenDir() {{{1
-" Open directory node with the "default" key, initially <CR>.
-function! s:defaultOpenDir(node)
+"FUNCTION: s:customOpenDir() {{{1
+" Open directory node with the "custom" key, initially <CR>.
+function! s:customOpenDir(node)
     call s:activateDirNode(a:node, g:NERDTreeCustomOpenArgs)
 endfunction
 
-"FUNCTION: s:defaultOpenBookmark() {{{1
-" Open bookmark node with the "default" key, initially <CR>.
-function! s:defaultOpenBookmark(node)
+"FUNCTION: s:customOpenBookmark() {{{1
+" Open bookmark node with the "custom" key, initially <CR>.
+function! s:customOpenBookmark(node)
     call a:node.activate(b:NERDTree, g:NERDTreeCustomOpenArgs)
 endfunction
 

--- a/autoload/nerdtree/ui_glue.vim
+++ b/autoload/nerdtree/ui_glue.vim
@@ -14,9 +14,9 @@ function! nerdtree#ui_glue#createDefaultBindings()
     call NERDTreeAddKeyMap({ 'key': '<2-LeftMouse>', 'scope': "Bookmark", 'callback': s."activateBookmark" })
     call NERDTreeAddKeyMap({ 'key': '<2-LeftMouse>', 'scope': "all", 'callback': s."activateAll" })
 
-    call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapUserDefOpen, 'scope':'FileNode', 'callback': s."defaultOpenFile"})
-    call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapUserDefOpen, 'scope':'DirNode', 'callback': s."defaultOpenDir"})
-    call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapUserDefOpen, 'scope':'Bookmark', 'callback': s."defaultOpenBookmark"})
+    call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapCustomOpen, 'scope':'FileNode', 'callback': s."defaultOpenFile"})
+    call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapCustomOpen, 'scope':'DirNode', 'callback': s."defaultOpenDir"})
+    call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapCustomOpen, 'scope':'Bookmark', 'callback': s."defaultOpenBookmark"})
 
     call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapActivateNode, 'scope': "DirNode", 'callback': s."activateDirNode" })
     call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapActivateNode, 'scope': "FileNode", 'callback': s."activateFileNode" })
@@ -82,19 +82,19 @@ endfunction
 "FUNCTION: s:defaultOpenFile() {{{1
 " Open file node with the "default" key, initially <CR>.
 function! s:defaultOpenFile(node)
-    call a:node.activate(g:NERDTreeUserDefOpenArgs)
+    call a:node.activate(g:NERDTreeCustomOpenArgs)
 endfunction
 
 "FUNCTION: s:defaultOpenDir() {{{1
 " Open directory node with the "default" key, initially <CR>.
 function! s:defaultOpenDir(node)
-    call s:activateDirNode(a:node, g:NERDTreeUserDefOpenArgs)
+    call s:activateDirNode(a:node, g:NERDTreeCustomOpenArgs)
 endfunction
 
 "FUNCTION: s:defaultOpenBookmark() {{{1
 " Open bookmark node with the "default" key, initially <CR>.
 function! s:defaultOpenBookmark(node)
-    call a:node.activate(b:NERDTree, g:NERDTreeUserDefOpenArgs)
+    call a:node.activate(b:NERDTree, g:NERDTreeCustomOpenArgs)
 endfunction
 
 "FUNCTION: s:activateAll() {{{1

--- a/autoload/nerdtree/ui_glue.vim
+++ b/autoload/nerdtree/ui_glue.vim
@@ -82,19 +82,30 @@ endfunction
 "FUNCTION: s:customOpenFile() {{{1
 " Open file node with the "custom" key, initially <CR>.
 function! s:customOpenFile(node)
-    call a:node.activate(g:NERDTreeCustomOpenArgs)
+    call a:node.activate(s:initCustomOpenArgs().file)
 endfunction
 
 "FUNCTION: s:customOpenDir() {{{1
 " Open directory node with the "custom" key, initially <CR>.
 function! s:customOpenDir(node)
-    call s:activateDirNode(a:node, g:NERDTreeCustomOpenArgs)
+    call s:activateDirNode(a:node, s:initCustomOpenArgs().dir)
 endfunction
 
 "FUNCTION: s:customOpenBookmark() {{{1
 " Open bookmark node with the "custom" key, initially <CR>.
 function! s:customOpenBookmark(node)
-    call a:node.activate(b:NERDTree, g:NERDTreeCustomOpenArgs)
+    if node.isDirectory
+        call a:node.activate(b:NERDTree, s:initCustomOpenArgs().dir)
+    else
+        call a:node.activate(b:NERDTree, s:initCustomOpenArgs().file)
+    endif
+endfunction
+
+"FUNCTION: s:initCustomOpenArgs() {{{1
+" Make sure NERDTreeCustomOpenArgs has needed keys
+function! s:initCustomOpenArgs()
+    let g:NERDTreeCustomOpenArgs = get(g:, 'NERDTreeCustomOpenArgs', {})
+    return extend(g:NERDTreeCustomOpenArgs, {'file':{'reuse': 'all', 'where': 'p'}, 'dir':{}}, 'keep')
 endfunction
 
 "FUNCTION: s:activateAll() {{{1

--- a/doc/NERDTree.txt
+++ b/doc/NERDTree.txt
@@ -247,7 +247,7 @@ i........Open selected file in a split window.......................|NERDTree-i|
 gi.......Same as i, but leave the cursor on the NERDTree...........|NERDTree-gi|
 s........Open selected file in a new vsplit.........................|NERDTree-s|
 gs.......Same as s, but leave the cursor on the NERDTree...........|NERDTree-gs|
-<CR>.....User-definable custom open action.......................|NERDTree-<CR>|
+<CR>.....User-definable custom open action.........................|NERDTree-CR|
 O........Recursively open the selected directory....................|NERDTree-O|
 x........Close the current nodes parent.............................|NERDTree-x|
 X........Recursively close all children of the current node.........|NERDTree-X|
@@ -378,7 +378,7 @@ The default key combo for this mapping is "g" + NERDTreeMapOpenVSplit (see
 |NERDTree-s|).
 
 ------------------------------------------------------------------------------
-                                                                 *NERDTree-<CR>*
+                                                                   *NERDTree-CR*
 Default key: <CR>
 Map setting: *NERDTreeMapCustomOpen*
 Applies to: files, directories, and bookmarks
@@ -764,7 +764,7 @@ the NERDTree. These settings should be set in your vimrc, using `:let`.
                             characters on the line of text.
 
 |NERDTreeCustomOpenArgs|      A dictionary with values that control how a node
-                            is opened with the |NERDTree-<CR>| key.
+                            is opened with the |NERDTree-CR| key.
 
 ------------------------------------------------------------------------------
 3.2. Customisation details                             *NERDTreeSettingsDetails*
@@ -1250,7 +1250,7 @@ when specifying by hex or Unicode. >
 Values: A dictionary, as described below
 Default: {'reuse': 'all', 'where': 'p'}
 
-This dictionary contains parameters used by |NERDTree-<CR>| to open a file.
+This dictionary contains parameters used by |NERDTree-CR| to open a file.
 Setting these parameters allows you to perform actions that you cannot do with
 the standard keys. The default value matches what |NERDTree-o| does. To change
 that behavior, use these keys and values in the dictionary:

--- a/doc/NERDTree.txt
+++ b/doc/NERDTree.txt
@@ -1247,13 +1247,15 @@ when specifying by hex or Unicode. >
 <
 ------------------------------------------------------------------------------
                                                         *NERDTreeCustomOpenArgs*
-Values: A dictionary, as described below
-Default: {'reuse': 'all', 'where': 'p'}
+Values: A nested dictionary, as described below
+Default: {'file': {'reuse': 'all', 'where': 'p'}, 'dir': {}}
 
-This dictionary contains parameters used by |NERDTree-CR| to open a file.
-Setting these parameters allows you to perform actions that you cannot do with
-the standard keys. The default value matches what |NERDTree-o| does. To change
-that behavior, use these keys and values in the dictionary:
+This dictionary contains two keys, 'file' and 'dir', whose values each are
+another dictionary. The inner dictionary is a set of parameters used by
+|NERDTree-CR| to open a file or directory. Setting these parameters allows you
+to customize the way the node is opened. The default value matches what
+|NERDTree-o| does. To change that behavior, use these keys and
+values in the inner dictionaries:
 
 'where':    specifies whether the node should be opened in a new split ("h" or
             "v"), in a new tab ("t") or, in the last window ("p").
@@ -1263,11 +1265,11 @@ that behavior, use these keys and values in the dictionary:
 'stay':     boolean (0 or 1); if true, remain in tree window after opening
 
 For example:
-To open a file in a new tab, >
-    let g:NERDTreeUserDefOpenArgs = {'where': 't'}
+To open files and directories (creating a new NERDTree) in a new tab, >
+    {'file':{'where': 't'}, 'dir':{'where':'t'}}
 <
-To open a file always in the current tab, >
-    let g:NERDTreeUserDefOpenArgs = {'reuse':'currenttab', 'where':'p'}
+To open a file always in the current tab, and expand directories in place, >
+    {'file': {'reuse':'currenttab', 'where':'p', 'keepopen':1, 'stay':1}}
 <
 ==============================================================================
 4. The NERDTree API                                                *NERDTreeAPI*

--- a/doc/NERDTree.txt
+++ b/doc/NERDTree.txt
@@ -247,12 +247,12 @@ i........Open selected file in a split window.......................|NERDTree-i|
 gi.......Same as i, but leave the cursor on the NERDTree...........|NERDTree-gi|
 s........Open selected file in a new vsplit.........................|NERDTree-s|
 gs.......Same as s, but leave the cursor on the NERDTree...........|NERDTree-gs|
+<CR>.....User-definable custom open action.......................|NERDTree-<CR>|
 O........Recursively open the selected directory....................|NERDTree-O|
 x........Close the current nodes parent.............................|NERDTree-x|
 X........Recursively close all children of the current node.........|NERDTree-X|
 e........Edit the current dir.......................................|NERDTree-e|
 
-<CR>............same as |NERDTree-o|.
 double-click....same as |NERDTree-o|.
 middle-click....same as |NERDTree-i| for files, and |NERDTree-e| for dirs.
 
@@ -377,6 +377,15 @@ The same as |NERDTree-s| except that the cursor is not moved.
 The default key combo for this mapping is "g" + NERDTreeMapOpenVSplit (see
 |NERDTree-s|).
 
+------------------------------------------------------------------------------
+                                                                 *NERDTree-<CR>*
+Default key: <CR>
+Map setting: *NERDTreeMapCustomOpen*
+Applies to: files, directories, and bookmarks
+
+Performs a customized open action on the selected node. This allows the user
+to define an action that behaves differently from any of the standard
+keys. See |NERDTreeCustomOpenArgs| for more details.
 ------------------------------------------------------------------------------
                                                                     *NERDTree-O*
 Default key: O
@@ -753,6 +762,9 @@ the NERDTree. These settings should be set in your vimrc, using `:let`.
 |NERDTreeNodeDelimiter|       A single character that is used to separate the
                             file or directory name from the rest of the
                             characters on the line of text.
+
+|NERDTreeCustomOpenArgs|      A dictionary with values that control how a node
+                            is opened with the |NERDTree-<CR>| key.
 
 ------------------------------------------------------------------------------
 3.2. Customisation details                             *NERDTreeSettingsDetails*
@@ -1232,6 +1244,30 @@ when specifying by hex or Unicode. >
     let NERDTreeNodeDelimiter="\u00b7"   "middle dot
     let NERDTreeNodeDelimiter="\u00a0"   "non-breaking space
     let NERDTreeNodeDelimiter="😀"       "smiley face
+<
+------------------------------------------------------------------------------
+                                                        *NERDTreeCustomOpenArgs*
+Values: A dictionary, as described below
+Default: {'reuse': 'all', 'where': 'p'}
+
+This dictionary contains parameters used by |NERDTree-<CR>| to open a file.
+Setting these parameters allows you to perform actions that you cannot do with
+the standard keys. The default value matches what |NERDTree-o| does. To change
+that behavior, use these keys and values in the dictionary:
+
+'where':    specifies whether the node should be opened in a new split ("h" or
+            "v"), in a new tab ("t") or, in the last window ("p").
+'reuse':    if file is already shown in a window, jump there; takes values
+            "all", "currenttab", or empty
+'keepopen': boolean (0 or 1); if true, the tree window will not be closed
+'stay':     boolean (0 or 1); if true, remain in tree window after opening
+
+For example:
+To open a file in a new tab, >
+    let g:NERDTreeUserDefOpenArgs = {'where': 't'}
+<
+To open a file always in the current tab, >
+    let g:NERDTreeUserDefOpenArgs = {'reuse':'currenttab', 'where':'p'}
 <
 ==============================================================================
 4. The NERDTree API                                                *NERDTreeAPI*

--- a/doc/NERDTree.txt
+++ b/doc/NERDTree.txt
@@ -319,7 +319,7 @@ The default key combo for this mapping is "g" + NERDTreeMapActivateNode (see
 ------------------------------------------------------------------------------
                                                                     *NERDTree-t*
 Default key: t
-Map setting: NERDTreeMapOpenInTab
+Map setting: *NERDTreeMapOpenInTab*
 Applies to: files and directories.
 
 Opens the selected file in a new tab. If a directory is selected, a fresh
@@ -332,7 +332,7 @@ in a new tab.
 ------------------------------------------------------------------------------
                                                                     *NERDTree-T*
 Default key: T
-Map setting: NERDTreeMapOpenInTabSilent
+Map setting: *NERDTreeMapOpenInTabSilent*
 Applies to: files and directories.
 
 The same as |NERDTree-t| except that the focus is kept in the current tab.
@@ -340,7 +340,7 @@ The same as |NERDTree-t| except that the focus is kept in the current tab.
 ------------------------------------------------------------------------------
                                                                     *NERDTree-i*
 Default key: i
-Map setting: NERDTreeMapOpenSplit
+Map setting: *NERDTreeMapOpenSplit*
 Applies to: files.
 
 Opens the selected file in a new split window and puts the cursor in the new
@@ -349,7 +349,7 @@ window.
 ------------------------------------------------------------------------------
                                                                    *NERDTree-gi*
 Default key: gi
-Map setting: NERDTreeMapPreviewSplit
+Map setting: *NERDTreeMapPreviewSplit*
 Applies to: files.
 
 The same as |NERDTree-i| except that the cursor is not moved.
@@ -360,7 +360,7 @@ The default key combo for this mapping is "g" + NERDTreeMapOpenSplit (see
 ------------------------------------------------------------------------------
                                                                     *NERDTree-s*
 Default key: s
-Map setting: NERDTreeMapOpenVSplit
+Map setting: *NERDTreeMapOpenVSplit*
 Applies to: files.
 
 Opens the selected file in a new vertically split window and puts the cursor
@@ -369,7 +369,7 @@ in the new window.
 ------------------------------------------------------------------------------
                                                                    *NERDTree-gs*
 Default key: gs
-Map setting: NERDTreeMapPreviewVSplit
+Map setting: *NERDTreeMapPreviewVSplit*
 Applies to: files.
 
 The same as |NERDTree-s| except that the cursor is not moved.
@@ -389,7 +389,7 @@ keys. See |NERDTreeCustomOpenArgs| for more details.
 ------------------------------------------------------------------------------
                                                                     *NERDTree-O*
 Default key: O
-Map setting: NERDTreeMapOpenRecursively
+Map setting: *NERDTreeMapOpenRecursively*
 Applies to: directories.
 
 Recursively opens the selected directory.
@@ -402,7 +402,7 @@ cached. This is handy, especially if you have .svn directories.
 ------------------------------------------------------------------------------
                                                                     *NERDTree-x*
 Default key: x
-Map setting: NERDTreeMapCloseDir
+Map setting: *NERDTreeMapCloseDir*
 Applies to: files and directories.
 
 Closes the parent of the selected node.
@@ -410,7 +410,7 @@ Closes the parent of the selected node.
 ------------------------------------------------------------------------------
                                                                     *NERDTree-X*
 Default key: X
-Map setting: NERDTreeMapCloseChildren
+Map setting: *NERDTreeMapCloseChildren*
 Applies to: directories.
 
 Recursively closes all children of the selected directory.
@@ -420,7 +420,7 @@ Tip: To quickly "reset" the tree, use |NERDTree-P| with this mapping.
 ------------------------------------------------------------------------------
                                                                     *NERDTree-e*
 Default key: e
-Map setting: NERDTreeMapOpenExpl
+Map setting: *NERDTreeMapOpenExpl*
 Applies to: files and directories.
 
 |:edit|s the selected directory, or the selected file's directory. This could
@@ -430,7 +430,7 @@ result in a NERDTree or a netrw being opened, depending on
 ------------------------------------------------------------------------------
                                                                     *NERDTree-D*
 Default key: D
-Map setting: NERDTreeMapDeleteBookmark
+Map setting: *NERDTreeMapDeleteBookmark*
 Applies to: lines in the bookmarks table
 
 Deletes the currently selected bookmark.
@@ -438,7 +438,7 @@ Deletes the currently selected bookmark.
 ------------------------------------------------------------------------------
                                                                     *NERDTree-P*
 Default key: P
-Map setting: NERDTreeMapJumpRoot
+Map setting: *NERDTreeMapJumpRoot*
 Applies to: no restrictions.
 
 Jump to the tree root.
@@ -446,7 +446,7 @@ Jump to the tree root.
 ------------------------------------------------------------------------------
                                                                     *NERDTree-p*
 Default key: p
-Map setting: NERDTreeMapJumpParent
+Map setting: *NERDTreeMapJumpParent*
 Applies to: files and directories.
 
 Jump to the parent node of the selected node.
@@ -454,7 +454,7 @@ Jump to the parent node of the selected node.
 ------------------------------------------------------------------------------
                                                                     *NERDTree-K*
 Default key: K
-Map setting: NERDTreeMapJumpFirstChild
+Map setting: *NERDTreeMapJumpFirstChild*
 Applies to: files and directories.
 
 Jump to the first child of the current nodes parent.
@@ -467,7 +467,7 @@ If the cursor is already on the first node then do the following:
 ------------------------------------------------------------------------------
                                                                     *NERDTree-J*
 Default key: J
-Map setting: NERDTreeMapJumpLastChild
+Map setting: *NERDTreeMapJumpLastChild*
 Applies to: files and directories.
 
 Jump to the last child of the current nodes parent.
@@ -480,7 +480,7 @@ If the cursor is already on the last node then do the following:
 ------------------------------------------------------------------------------
                                                                   *NERDTree-C-J*
 Default key: <C-J>
-Map setting: NERDTreeMapJumpNextSibling
+Map setting: *NERDTreeMapJumpNextSibling*
 Applies to: files and directories.
 
 Jump to the next sibling of the selected node.
@@ -488,7 +488,7 @@ Jump to the next sibling of the selected node.
 ------------------------------------------------------------------------------
                                                                   *NERDTree-C-K*
 Default key: <C-K>
-Map setting: NERDTreeMapJumpPrevSibling
+Map setting: *NERDTreeMapJumpPrevSibling*
 Applies to: files and directories.
 
 Jump to the previous sibling of the selected node.
@@ -496,7 +496,7 @@ Jump to the previous sibling of the selected node.
 ------------------------------------------------------------------------------
                                                                     *NERDTree-C*
 Default key: C
-Map setting: NERDTreeMapChangeRoot
+Map setting: *NERDTreeMapChangeRoot*
 Applies to: files and directories.
 
 Make the selected directory node the new tree root. If a file is selected, its
@@ -505,7 +505,7 @@ parent is used.
 ------------------------------------------------------------------------------
                                                                     *NERDTree-u*
 Default key: u
-Map setting: NERDTreeMapUpdir
+Map setting: *NERDTreeMapUpdir*
 Applies to: no restrictions.
 
 Move the tree root up a dir (like doing a "cd ..").
@@ -513,7 +513,7 @@ Move the tree root up a dir (like doing a "cd ..").
 ------------------------------------------------------------------------------
                                                                     *NERDTree-U*
 Default key: U
-Map setting: NERDTreeMapUpdirKeepOpen
+Map setting: *NERDTreeMapUpdirKeepOpen*
 Applies to: no restrictions.
 
 Like |NERDTree-u| except that the old tree root is kept open.
@@ -521,7 +521,7 @@ Like |NERDTree-u| except that the old tree root is kept open.
 ------------------------------------------------------------------------------
                                                                     *NERDTree-r*
 Default key: r
-Map setting: NERDTreeMapRefresh
+Map setting: *NERDTreeMapRefresh*
 Applies to: files and directories.
 
 If a dir is selected, recursively refresh that dir, i.e. scan the filesystem
@@ -532,7 +532,7 @@ If a file node is selected then the above is done on it's parent.
 ------------------------------------------------------------------------------
                                                                     *NERDTree-R*
 Default key: R
-Map setting: NERDTreeMapRefreshRoot
+Map setting: *NERDTreeMapRefreshRoot*
 Applies to: no restrictions.
 
 Recursively refresh the tree root.
@@ -540,7 +540,7 @@ Recursively refresh the tree root.
 ------------------------------------------------------------------------------
                                                                     *NERDTree-m*
 Default key: m
-Map setting: NERDTreeMapMenu
+Map setting: *NERDTreeMapMenu*
 Applies to: files and directories.
 
 Display the NERDTree menu. See |NERDTreeMenu| for details.
@@ -548,7 +548,7 @@ Display the NERDTree menu. See |NERDTreeMenu| for details.
 ------------------------------------------------------------------------------
                                                                    *NERDTree-cd*
 Default key: cd
-Map setting: NERDTreeMapChdir
+Map setting: *NERDTreeMapChdir*
 Applies to: files and directories.
 
 Change Vim's current working directory to that of the selected node.
@@ -556,7 +556,7 @@ Change Vim's current working directory to that of the selected node.
 ------------------------------------------------------------------------------
                                                                    *NERDTree-CD*
 Default key: CD
-Map setting: NERDTreeMapCWD
+Map setting: *NERDTreeMapCWD*
 Applies to: no restrictions.
 
 Change the NERDTree root to Vim's current working directory.
@@ -564,7 +564,7 @@ Change the NERDTree root to Vim's current working directory.
 ------------------------------------------------------------------------------
                                                                     *NERDTree-I*
 Default key: I
-Map setting: NERDTreeMapToggleHidden
+Map setting: *NERDTreeMapToggleHidden*
 Applies to: no restrictions.
 
 Toggles whether hidden files (i.e. "dot files") are displayed.
@@ -572,7 +572,7 @@ Toggles whether hidden files (i.e. "dot files") are displayed.
 ------------------------------------------------------------------------------
                                                                     *NERDTree-f*
 Default key: f
-Map setting: NERDTreeMapToggleFilters
+Map setting: *NERDTreeMapToggleFilters*
 Applies to: no restrictions.
 
 Toggles whether file filters are used. See |NERDTreeIgnore| for details.
@@ -580,7 +580,7 @@ Toggles whether file filters are used. See |NERDTreeIgnore| for details.
 ------------------------------------------------------------------------------
                                                                     *NERDTree-F*
 Default key: F
-Map setting: NERDTreeMapToggleFiles
+Map setting: *NERDTreeMapToggleFiles*
 Applies to: no restrictions.
 
 Toggles whether file nodes are displayed.
@@ -588,7 +588,7 @@ Toggles whether file nodes are displayed.
 ------------------------------------------------------------------------------
                                                                     *NERDTree-B*
 Default key: B
-Map setting: NERDTreeMapToggleBookmarks
+Map setting: *NERDTreeMapToggleBookmarks*
 Applies to: no restrictions.
 
 Toggles whether the bookmarks table is displayed.
@@ -596,7 +596,7 @@ Toggles whether the bookmarks table is displayed.
 ------------------------------------------------------------------------------
                                                                     *NERDTree-q*
 Default key: q
-Map setting: NERDTreeMapQuit
+Map setting: *NERDTreeMapQuit*
 Applies to: no restrictions.
 
 Closes the NERDTree window.
@@ -604,7 +604,7 @@ Closes the NERDTree window.
 ------------------------------------------------------------------------------
                                                                     *NERDTree-A*
 Default key: A
-Map setting: NERDTreeMapToggleZoom
+Map setting: *NERDTreeMapToggleZoom*
 Applies to: no restrictions.
 
 Maximize (zoom) and minimize the NERDTree window.
@@ -612,7 +612,7 @@ Maximize (zoom) and minimize the NERDTree window.
 ------------------------------------------------------------------------------
                                                                     *NERDTree-?*
 Default key: ?
-Map setting: NERDTreeMapHelp
+Map setting: *NERDTreeMapHelp*
 Applies to: no restrictions.
 
 Toggles whether the quickhelp is displayed.
@@ -634,7 +634,7 @@ Related tags: |NERDTree-m| |NERDTreeApi|
 ------------------------------------------------------------------------------
                                                                 *NERDTreeMenu-j*
 Default key: j
-Map option: NERDTreeMenuDown
+Map option: *NERDTreeMenuDown*
 Applies to: The NERDTree menu.
 
 Moves the cursor down.
@@ -642,7 +642,7 @@ Moves the cursor down.
 ------------------------------------------------------------------------------
                                                                 *NERDTreeMenu-k*
 Default key: k
-Map option: NERDTreeMenuUp
+Map option: *NERDTreeMenuUp*
 Applies to: The NERDTree menu.
 
 Moves the cursor up.

--- a/doc/NERDTree.txt
+++ b/doc/NERDTree.txt
@@ -247,7 +247,7 @@ i........Open selected file in a split window.......................|NERDTree-i|
 gi.......Same as i, but leave the cursor on the NERDTree...........|NERDTree-gi|
 s........Open selected file in a new vsplit.........................|NERDTree-s|
 gs.......Same as s, but leave the cursor on the NERDTree...........|NERDTree-gs|
-<CR>.....User-definable custom open action.........................|NERDTree-CR|
+<CR>.....User-definable custom open action.......................|NERDTree-<CR>|
 O........Recursively open the selected directory....................|NERDTree-O|
 x........Close the current nodes parent.............................|NERDTree-x|
 X........Recursively close all children of the current node.........|NERDTree-X|
@@ -378,7 +378,7 @@ The default key combo for this mapping is "g" + NERDTreeMapOpenVSplit (see
 |NERDTree-s|).
 
 ------------------------------------------------------------------------------
-                                                                   *NERDTree-CR*
+                                                                 *NERDTree-<CR>*
 Default key: <CR>
 Map setting: *NERDTreeMapCustomOpen*
 Applies to: files, directories, and bookmarks
@@ -764,7 +764,7 @@ the NERDTree. These settings should be set in your vimrc, using `:let`.
                             characters on the line of text.
 
 |NERDTreeCustomOpenArgs|      A dictionary with values that control how a node
-                            is opened with the |NERDTree-CR| key.
+                            is opened with the |NERDTree-<CR>| key.
 
 ------------------------------------------------------------------------------
 3.2. Customisation details                             *NERDTreeSettingsDetails*
@@ -1252,7 +1252,7 @@ Default: {'file': {'reuse': 'all', 'where': 'p'}, 'dir': {}}
 
 This dictionary contains two keys, 'file' and 'dir', whose values each are
 another dictionary. The inner dictionary is a set of parameters used by
-|NERDTree-CR| to open a file or directory. Setting these parameters allows you
+|NERDTree-<CR>| to open a file or directory. Setting these parameters allows you
 to customize the way the node is opened. The default value matches what
 |NERDTree-o| does. To change that behavior, use these keys and
 values in the inner dictionaries:

--- a/lib/nerdtree/creator.vim
+++ b/lib/nerdtree/creator.vim
@@ -13,9 +13,6 @@ let g:NERDTreeCreator = s:Creator
 
 " FUNCTION: s:Creator._bindMappings() {{{1
 function! s:Creator._bindMappings()
-    "make <cr> do the same as the activate node mapping
-    nnoremap <silent> <buffer> <cr> :call nerdtree#ui_glue#invokeKeyMap(g:NERDTreeMapActivateNode)<cr>
-
     call g:NERDTreeKeyMap.BindAll()
 
     command! -buffer -nargs=? Bookmark :call nerdtree#ui_glue#bookmarkNode('<args>')

--- a/lib/nerdtree/ui.vim
+++ b/lib/nerdtree/ui.vim
@@ -28,7 +28,6 @@ function! s:UI._dumpHelp()
         let help .= "\" ============================\n"
         let help .= "\" File node mappings~\n"
         let help .= "\" ". (g:NERDTreeMouseMode ==# 3 ? "single" : "double") ."-click,\n"
-        let help .= "\" <CR>,\n"
         if self.nerdtree.isTabTree()
             let help .= "\" ". g:NERDTreeMapActivateNode .": open in prev window\n"
         else
@@ -44,6 +43,7 @@ function! s:UI._dumpHelp()
         let help .= "\" ". g:NERDTreeMapPreviewSplit .": preview split\n"
         let help .= "\" ". g:NERDTreeMapOpenVSplit .": open vsplit\n"
         let help .= "\" ". g:NERDTreeMapPreviewVSplit .": preview vsplit\n"
+        let help .= "\" ". g:NERDTreeMapCustomOpen .": custom open\n"
 
         let help .= "\"\n\" ----------------------------\n"
         let help .= "\" Directory node mappings~\n"
@@ -52,6 +52,7 @@ function! s:UI._dumpHelp()
         let help .= "\" ". g:NERDTreeMapOpenRecursively .": recursively open node\n"
         let help .= "\" ". g:NERDTreeMapOpenInTab.": open in new tab\n"
         let help .= "\" ". g:NERDTreeMapOpenInTabSilent .": open in new tab silently\n"
+        let help .= "\" ". g:NERDTreeMapCustomOpen .": custom open\n"
         let help .= "\" ". g:NERDTreeMapCloseDir .": close parent of node\n"
         let help .= "\" ". g:NERDTreeMapCloseChildren .": close all child nodes of\n"
         let help .= "\"    current node recursively\n"
@@ -66,6 +67,7 @@ function! s:UI._dumpHelp()
         let help .= "\" ". g:NERDTreeMapPreview .": find dir in tree\n"
         let help .= "\" ". g:NERDTreeMapOpenInTab.": open in new tab\n"
         let help .= "\" ". g:NERDTreeMapOpenInTabSilent .": open in new tab silently\n"
+        let help .= "\" ". g:NERDTreeMapCustomOpen .": custom open\n"
         let help .= "\" ". g:NERDTreeMapDeleteBookmark .": delete bookmark\n"
 
         let help .= "\"\n\" ----------------------------\n"

--- a/plugin/NERD_tree.vim
+++ b/plugin/NERD_tree.vim
@@ -107,6 +107,10 @@ endif
 call s:initVariable("g:NERDTreeWinPos", "left")
 call s:initVariable("g:NERDTreeWinSize", 31)
 
+if !exists('g:NERDTreeUserDefOpenArgs')
+    let g:NERDTreeUserDefOpenArgs = {'reuse': 'all', 'where': 'p'}
+endif
+
 "init the shell commands that will be used to copy nodes, and remove dir trees
 "
 "Note: the space after the command is important
@@ -121,6 +125,7 @@ endif
 
 
 "SECTION: Init variable calls for key mappings {{{2
+call s:initVariable("g:NERDTreeMapUserDefOpen", "<CR>")
 call s:initVariable("g:NERDTreeMapActivateNode", "o")
 call s:initVariable("g:NERDTreeMapChangeRoot", "C")
 call s:initVariable("g:NERDTreeMapChdir", "cd")

--- a/plugin/NERD_tree.vim
+++ b/plugin/NERD_tree.vim
@@ -107,10 +107,6 @@ endif
 call s:initVariable("g:NERDTreeWinPos", "left")
 call s:initVariable("g:NERDTreeWinSize", 31)
 
-if !exists('g:NERDTreeCustomOpenArgs')
-    let g:NERDTreeCustomOpenArgs = {'reuse': 'all', 'where': 'p'}
-endif
-
 "init the shell commands that will be used to copy nodes, and remove dir trees
 "
 "Note: the space after the command is important

--- a/plugin/NERD_tree.vim
+++ b/plugin/NERD_tree.vim
@@ -107,8 +107,8 @@ endif
 call s:initVariable("g:NERDTreeWinPos", "left")
 call s:initVariable("g:NERDTreeWinSize", 31)
 
-if !exists('g:NERDTreeUserDefOpenArgs')
-    let g:NERDTreeUserDefOpenArgs = {'reuse': 'all', 'where': 'p'}
+if !exists('g:NERDTreeCustomOpenArgs')
+    let g:NERDTreeCustomOpenArgs = {'reuse': 'all', 'where': 'p'}
 endif
 
 "init the shell commands that will be used to copy nodes, and remove dir trees
@@ -125,7 +125,7 @@ endif
 
 
 "SECTION: Init variable calls for key mappings {{{2
-call s:initVariable("g:NERDTreeMapUserDefOpen", "<CR>")
+call s:initVariable("g:NERDTreeMapCustomOpen", "<CR>")
 call s:initVariable("g:NERDTreeMapActivateNode", "o")
 call s:initVariable("g:NERDTreeMapChangeRoot", "C")
 call s:initVariable("g:NERDTreeMapChdir", "cd")


### PR DESCRIPTION
<!-- Enter the issue number this PR addresses below. If none, remove the line. -->
### Description of Changes

Closes #551
Closes #631

This change creates a customizable key mapping that can open files or directories in a way that is different from the normal commands. By default, it is set to `<CR>`, the Enter key, and its action is to do the same thing as the `o` key. But the key assigned to this action, and the options given to the internal NERDTree `open` functions, can be changed. The documentation describes the values that can be set in these options.

This pull request addresses two outstanding issues.

#551 - **Use Enter to open a file in a new tab.** To do this, add the following to your .vimrc.
```
let NERDTreeCustomOpenArgs = {'file':{'where':'t'}}
```
#631 - **Use Enter to open a file in the current tab, even if open in another one.** This requires the reuse flag to be overridden, and is done with this code in your .vimrc.
```
let NERDTreeCustomOpenArgs = {'file': {'reuse':'currenttab', 'where':'p', 'keepopen':1, 'stay':1}}
```
Many other such customizations are possible, and are documented in the NERDTree help file.

---
### New Version Info

- [x] Derive a new version number. Increment the:
    - [ ] `MAJOR` version when you make incompatible API changes,
    - [x] `MINOR` version when you add functionality in a backwards-compatible manner, and
    - [ ] `PATCH` version when you make backwards-compatible bug fixes.
- [x] Update version number in [autoload/nerdtree.vim](https://github.com/scrooloose/nerdtree/blob/master/autoload/nerdtree.vim#L7)
- [x] Update the ChangeLog, following this format/example:
    ```
    MAJOR.MINOR...
    - **.PATCH**: PR Title (Author) #PR Number

    ### 5.1...
    - **.1**: Update Changelog and create PR Template (PhilRunninger) #1007
    - **.0**: Too many changes for one patch...
    ```