### PR TITLE
Make Enter work on the `.. ( up a dir )` line

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -22,9 +22,8 @@ After reading, and before submitting your issue, please remove this introductory
 
 #### Environment (for bug reports)
 - [ ] Operating System: 
-- [ ] Vim/Neovim version `:version`: 
-- [ ] NERDTree version `:echo nerdtree#version(0)` or `git rev-parse --short HEAD`: 
-- [ ] A link to my [vimrc](), or
+- [ ] Vim/Neovim version `:echo v:version`: 
+- [ ] NERDTree version, found on 1st line in NERDTree quickhelp `?`: 
 - [ ] vimrc settings
     - [ ] NERDTree variables
     ```vim

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 
 #### 5.2...
+- **.2**: Make Enter work on the `.. ( up a dir )` line (PhilRunninger) #1013
 - **.1**: Fix nerdtree#version() on Windows. (PhilRunninger) N/A
 - **.0**: Expand functionality of `<CR>` mapping. (PhilRunninger) #1011
 #### 5.1...

--- a/autoload/nerdtree/ui_glue.vim
+++ b/autoload/nerdtree/ui_glue.vim
@@ -17,6 +17,7 @@ function! nerdtree#ui_glue#createDefaultBindings()
     call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapCustomOpen, 'scope':'FileNode', 'callback': s."customOpenFile"})
     call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapCustomOpen, 'scope':'DirNode', 'callback': s."customOpenDir"})
     call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapCustomOpen, 'scope':'Bookmark', 'callback': s."customOpenBookmark"})
+    call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapCustomOpen, 'scope':'all', 'callback': s."activateAll" })
 
     call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapActivateNode, 'scope': "DirNode", 'callback': s."activateDirNode" })
     call NERDTreeAddKeyMap({ 'key': g:NERDTreeMapActivateNode, 'scope': "FileNode", 'callback': s."activateFileNode" })


### PR DESCRIPTION
### Description of Changes
Closes #1012  <!-- Issue number this PR addresses. If none, remove this line. -->

Added a callback to handle cases where a node is not found on the tree, as is the case when selecting the `.. ( up a dir )` line.

---
### New Version Info

- [x] Derive a new version number. Increment the:
    - [ ] `MAJOR` version when you make incompatible API changes
    - [ ] `MINOR` version when you add functionality in a backwards-compatible manner
    - [x] `PATCH` version when you make backwards-compatible bug fixes
- [x] Update [CHANGELOG.md](https://github.com/scrooloose/nerdtree/blob/master/CHANGELOG.md), following this format/example:
    ```
    #### MAJOR.MINOR...
    - **.PATCH**: PR Title (Author) #PR Number

    #### 5.1...
    - **.1**: Update Changelog and create PR Template (PhilRunninger) #1007
    - **.0**: Too many changes for one patch...
    ```
