### PR TITLE
When searching for root line num, stop at the end of the file.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 
 #### 5.2...
+- **.4**: When searching for root line num, stop at end of file. (PhilRunninger) #1015
 - **.3**: Fix `<CR>` key map on the bookmark (lkebin) #1014
 - **.2**: Make Enter work on the `.. ( up a dir )` line (PhilRunninger) #1013
 - **.1**: Fix nerdtree#version() on Windows. (PhilRunninger) N/A

--- a/lib/nerdtree/ui.vim
+++ b/lib/nerdtree/ui.vim
@@ -254,7 +254,7 @@ endfunction
 " gets the line number of the root node
 function! s:UI.getRootLineNum()
     let rootLine = 1
-    while getline(rootLine) !~# '^\(/\|<\)'
+    while rootLine <= line('$') && getline(rootLine) !~# '^\(/\|<\)'
         let rootLine = rootLine + 1
     endwhile
     return rootLine


### PR DESCRIPTION
When using the following NERDTreeStatusLine, Vim would lock up and not
work anymore. The problem was that when trying to find the root line
number, the loop was continuing past the end of the file, looping
"forever". The fix was to simply stop at the end of the file.

let g:NERDTreeStatusline = "%{exists('g:NERDTreeFileNode')&&" .
      \ "has_key(g:NERDTreeFileNode.GetSelected(),'path')?" .
      \ "g:NERDTreeFileNode.GetSelected().path.getLastPathComponent(0):''}"

### Description of Changes
Closes #467  <!-- Issue number this PR addresses. If none, remove this line. -->

---
### New Version Info

- [x] Derive a new version number. Increment the:
    - [ ] `MAJOR` version when you make incompatible API changes
    - [ ] `MINOR` version when you add functionality in a backwards-compatible manner
    - [x] `PATCH` version when you make backwards-compatible bug fixes
- [x] Update [CHANGELOG.md](https://github.com/scrooloose/nerdtree/blob/master/CHANGELOG.md), following this format/example:
    ```
    #### MAJOR.MINOR...
    - **.PATCH**: PR Title (Author) #PR Number

    #### 5.1...
    - **.1**: Update Changelog and create PR Template (PhilRunninger) #1007
    - **.0**: Too many changes for one patch...
    ```
