### PR TITLE
Use :mode instead of :redraw! when updating menu.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 
 #### 5.2...
+- **.4**: Use `:mode` instead of `:redraw!` when updating menu. (PhilRunninger) #1016
 - **.3**: Fix `<CR>` key map on the bookmark (lkebin) #1014
 - **.2**: Make Enter work on the `.. ( up a dir )` line (PhilRunninger) #1013
 - **.1**: Fix nerdtree#version() on Windows. (PhilRunninger) N/A

--- a/lib/nerdtree/menu_controller.vim
+++ b/lib/nerdtree/menu_controller.vim
@@ -31,7 +31,7 @@ function! s:MenuController.showMenu()
         let l:done = 0
 
         while !l:done
-            redraw!
+            mode
             call self._echoPrompt()
 
             let l:key = nr2char(getchar())


### PR DESCRIPTION
### Description of Changes
Closes #944.  <!-- Issue number this PR addresses. If none, remove this line. -->

Inferring from https://github.com/neovim/neovim/issues/10279#issuecomment-503688898, the command that we need to be using is `:mode` because it will clear the screen before redrawing. `:redraw!` apparently is a little more selective about what it will clear before redrawing the text, and was leaving the NERDTree menu on the screen when refreshing it.

---
### New Version Info

- [x] Derive a new version number. Increment the:
    - [ ] `MAJOR` version when you make incompatible API changes
    - [ ] `MINOR` version when you add functionality in a backwards-compatible manner
    - [x] `PATCH` version when you make backwards-compatible bug fixes
- [x] Update [CHANGELOG.md](https://github.com/scrooloose/nerdtree/blob/master/CHANGELOG.md), following this format/example:
    ```
    #### MAJOR.MINOR...
    - **.PATCH**: PR Title (Author) #PR Number

    #### 5.1...
    - **.1**: Update Changelog and create PR Template (PhilRunninger) #1007
    - **.0**: Too many changes for one patch...
    ```
