### PR TITLE
Use :mode only in neovim. MacVim still needs to use :redraw!

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 
 #### 5.2...
+- **.7**: Use :mode only in neovim. MacVim still needs to use :redraw! [#1019](https://github.com/scrooloose/nerdtree/pull/1019)
 - **.6**: In CHANGELOG.md and PR template, make reference to PR a true HTML link. [#1017](https://github.com/scrooloose/nerdtree/pull/1017)
 - **.5**: Use `:mode` instead of `:redraw!` when updating menu. (PhilRunninger) [#1016](https://github.com/scrooloose/nerdtree/pull/1016)
 - **.4**: When searching for root line num, stop at end of file. (PhilRunninger) [#1015](https://github.com/scrooloose/nerdtree/pull/1015)

--- a/autoload/nerdtree.vim
+++ b/autoload/nerdtree.vim
@@ -232,7 +232,7 @@ endfunction
 "Args:
 "msg: the message to echo
 function! nerdtree#echo(msg)
-    redraw
+    call nerdtree#redraw(0)
     echomsg empty(a:msg) ? "" : ("NERDTree: " . a:msg)
 endfunction
 

--- a/autoload/nerdtree.vim
+++ b/autoload/nerdtree.vim
@@ -22,6 +22,14 @@ endfunction
 " SECTION: General Functions {{{1
 "============================================================
 
+function! nerdtree#redraw()
+    if has('nvim')
+        mode
+    else
+        redraw!
+    endif
+endfunction
+
 function! nerdtree#slash()
 
     if nerdtree#runningWindows()

--- a/autoload/nerdtree.vim
+++ b/autoload/nerdtree.vim
@@ -22,16 +22,24 @@ endfunction
 " SECTION: General Functions {{{1
 "============================================================
 
-function! nerdtree#redraw()
+"FUNCTION: nerdtree#redraw([bang])
+" Redraws the screen (Neovim uses the mode statement). bang is an optional
+" parameter if present and TRUE, use redraw!, not redraw.
+function! nerdtree#redraw(...)
     if has('nvim')
         mode
     else
-        redraw!
+        if a:0 > 0 && a:1
+            redraw!
+        else
+            redraw
+        endif
     endif
 endfunction
 
+"FUNCTION: nerdtree#slash()
+" Returns the directory separator based on OS and &shellslash
 function! nerdtree#slash()
-
     if nerdtree#runningWindows()
         if exists('+shellslash') && &shellslash
             return '/'

--- a/autoload/nerdtree.vim
+++ b/autoload/nerdtree.vim
@@ -22,14 +22,14 @@ endfunction
 " SECTION: General Functions {{{1
 "============================================================
 
-"FUNCTION: nerdtree#redraw([bang])
-" Redraws the screen (Neovim uses the mode statement). bang is an optional
-" parameter if present and TRUE, use redraw!, not redraw.
-function! nerdtree#redraw(...)
+"FUNCTION: nerdtree#redraw(bang)
+" Redraws the screen (Neovim uses the mode statement). If bang is TRUE, use
+" redraw! instead of redraw.
+function! nerdtree#redraw(bang)
     if has('nvim')
         mode
     else
-        if a:0 > 0 && a:1
+        if a:bang
             redraw!
         else
             redraw

--- a/autoload/nerdtree/ui_glue.vim
+++ b/autoload/nerdtree/ui_glue.vim
@@ -254,7 +254,7 @@ function! s:deleteBookmark(bookmark)
 
     let l:choices = "&Yes\n&No"
 
-    echo | redraw
+    echo | call nerdtree#redraw(0)
     let l:selection = confirm(l:message, l:choices, 1, 'Warning')
 
     if l:selection != 1
@@ -266,7 +266,7 @@ function! s:deleteBookmark(bookmark)
         call a:bookmark.delete()
         silent call b:NERDTree.root.refresh()
         call b:NERDTree.render()
-        echo | redraw
+        echo | call nerdtree#redraw(0)
     catch /^NERDTree/
         call nerdtree#echoWarning('could not remove bookmark')
     endtry
@@ -577,7 +577,7 @@ function! s:refreshRoot()
     call nerdtree#exec(g:NERDTree.GetWinNum() . "wincmd w")
     call b:NERDTree.root.refresh()
     call b:NERDTree.render()
-    redraw
+    call nerdtree#redraw(0)
     call nerdtree#exec(l:curWin . "wincmd w")
     call nerdtree#echo("")
 endfunction

--- a/lib/nerdtree/menu_controller.vim
+++ b/lib/nerdtree/menu_controller.vim
@@ -31,7 +31,7 @@ function! s:MenuController.showMenu()
         let l:done = 0
 
         while !l:done
-            call nerdtree#redraw()
+            call nerdtree#redraw(1)
             call self._echoPrompt()
 
             let l:key = nr2char(getchar())
@@ -42,7 +42,7 @@ function! s:MenuController.showMenu()
 
         " Redraw when "Ctrl-C" or "Esc" is received.
         if !l:done || self.selection == -1
-            call nerdtree#redraw()
+            call nerdtree#redraw(1)
         endif
     endtry
 

--- a/lib/nerdtree/menu_controller.vim
+++ b/lib/nerdtree/menu_controller.vim
@@ -31,7 +31,7 @@ function! s:MenuController.showMenu()
         let l:done = 0
 
         while !l:done
-            mode
+            call nerdtree#redraw()
             call self._echoPrompt()
 
             let l:key = nr2char(getchar())
@@ -42,7 +42,7 @@ function! s:MenuController.showMenu()
 
         " Redraw when "Ctrl-C" or "Esc" is received.
         if !l:done || self.selection == -1
-            redraw!
+            call nerdtree#redraw()
         endif
     endtry
 

--- a/nerdtree_plugin/fs_menu.vim
+++ b/nerdtree_plugin/fs_menu.vim
@@ -78,7 +78,7 @@ function! s:inputPrompt(action)
     endif
 
     if g:NERDTreeMenuController.isMinimal()
-        redraw! " Clear the menu
+        call nerdtree#redraw(1) " Clear the menu
         return minimal . " "
     else
         let divider = "=========================================================="
@@ -185,7 +185,7 @@ function! NERDTreeAddNode()
             call newTreeNode.putCursorHere(1, 0)
         endif
 
-        redraw!
+        call nerdtree#redraw(1)
     catch /^NERDTree/
         call nerdtree#echoWarning("Node Not Created.")
     endtry
@@ -234,7 +234,7 @@ function! NERDTreeMoveNode()
 
         call curNode.putCursorHere(1, 0)
 
-        redraw!
+        call nerdtree#redraw(1)
     catch /^NERDTree/
         call nerdtree#echoWarning("Node Not Renamed.")
     endtry
@@ -272,7 +272,7 @@ function! NERDTreeDeleteNode()
                 call s:promptToDelBuffer(bufnum, prompt)
             endif
 
-            redraw!
+            call nerdtree#redraw(1)
         catch /^NERDTree/
             call nerdtree#echoWarning("Could not remove node")
         endtry
@@ -362,7 +362,7 @@ function! NERDTreeCopyNode()
         call nerdtree#echo("Copy aborted.")
     endif
     let &shellslash = l:shellslash
-    redraw!
+    call nerdtree#redraw(1)
 endfunction
 
 " FUNCTION: NERDTreeCopyPath() {{{1


### PR DESCRIPTION
### Description of Changes
As reported in https://github.com/scrooloose/nerdtree/commit/3b1a850b85a1b160817c35872bf1978f112958bf#r34251299, MacVim has the same problem with `:mode` that neovim has with `:redraw!` in the NERDtree menu. I made an autoload function that handles both cases (with `if has('nvim')`), and swapped it in for all the `redraw` and `redraw!` statements.

---
### New Version Info

- [x] Derive a new version number. Increment the:
    - [ ] `MAJOR` version when you make incompatible API changes
    - [ ] `MINOR` version when you add functionality in a backwards-compatible manner
    - [x] `PATCH` version when you make backwards-compatible bug fixes
- [x] Update [CHANGELOG.md](https://github.com/scrooloose/nerdtree/blob/master/CHANGELOG.md), following this format/example:
    ```
    #### MAJOR.MINOR...
    - **.PATCH**: PR Title (Author) [#PR Number](link to PR)

    #### 5.1...
    - **.1**: Update Changelog and create PR Template (PhilRunninger) [#1007](https://github.com/scrooloose/nerdtree/pull/1007)
    - **.0**: Too many changes for one patch...
    ```
