### PR TITLE
Revert #1019 to fix nvim artifacts and flickering.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,6 @@
 # Change Log
 
 #### 5.2...
-- **.7**: Use :mode only in neovim. MacVim still needs to use :redraw! [#1019](https://github.com/scrooloose/nerdtree/pull/1019)
 - **.6**: In CHANGELOG.md and PR template, make reference to PR a true HTML link. [#1017](https://github.com/scrooloose/nerdtree/pull/1017)
 - **.5**: Use `:mode` instead of `:redraw!` when updating menu. (PhilRunninger) [#1016](https://github.com/scrooloose/nerdtree/pull/1016)
 - **.4**: When searching for root line num, stop at end of file. (PhilRunninger) [#1015](https://github.com/scrooloose/nerdtree/pull/1015)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change Log
 
 #### 5.2...
+- **.8**: Revert [#1019](https://github.com/scrooloose/nerdtree/pull/1019) to fix nvim artifacts and flickering. (PhilRunninger) [#1021](https://github.com/scrooloose/nerdtree/pull/1021)
+- **.7**: Use :mode only in neovim. MacVim still needs to use :redraw! [#1019](https://github.com/scrooloose/nerdtree/pull/1019)
 - **.6**: In CHANGELOG.md and PR template, make reference to PR a true HTML link. [#1017](https://github.com/scrooloose/nerdtree/pull/1017)
 - **.5**: Use `:mode` instead of `:redraw!` when updating menu. (PhilRunninger) [#1016](https://github.com/scrooloose/nerdtree/pull/1016)
 - **.4**: When searching for root line num, stop at end of file. (PhilRunninger) [#1015](https://github.com/scrooloose/nerdtree/pull/1015)

--- a/autoload/nerdtree.vim
+++ b/autoload/nerdtree.vim
@@ -22,24 +22,8 @@ endfunction
 " SECTION: General Functions {{{1
 "============================================================
 
-"FUNCTION: nerdtree#redraw(bang)
-" Redraws the screen (Neovim uses the mode statement). If bang is TRUE, use
-" redraw! instead of redraw.
-function! nerdtree#redraw(bang)
-    if has('nvim')
-        mode
-    else
-        if a:bang
-            redraw!
-        else
-            redraw
-        endif
-    endif
-endfunction
-
-"FUNCTION: nerdtree#slash()
-" Returns the directory separator based on OS and &shellslash
 function! nerdtree#slash()
+
     if nerdtree#runningWindows()
         if exists('+shellslash') && &shellslash
             return '/'
@@ -232,7 +216,7 @@ endfunction
 "Args:
 "msg: the message to echo
 function! nerdtree#echo(msg)
-    call nerdtree#redraw(0)
+    redraw
     echomsg empty(a:msg) ? "" : ("NERDTree: " . a:msg)
 endfunction
 

--- a/autoload/nerdtree/ui_glue.vim
+++ b/autoload/nerdtree/ui_glue.vim
@@ -254,7 +254,7 @@ function! s:deleteBookmark(bookmark)
 
     let l:choices = "&Yes\n&No"
 
-    echo | call nerdtree#redraw(0)
+    echo | redraw
     let l:selection = confirm(l:message, l:choices, 1, 'Warning')
 
     if l:selection != 1
@@ -266,7 +266,7 @@ function! s:deleteBookmark(bookmark)
         call a:bookmark.delete()
         silent call b:NERDTree.root.refresh()
         call b:NERDTree.render()
-        echo | call nerdtree#redraw(0)
+        echo | redraw
     catch /^NERDTree/
         call nerdtree#echoWarning('could not remove bookmark')
     endtry
@@ -577,7 +577,7 @@ function! s:refreshRoot()
     call nerdtree#exec(g:NERDTree.GetWinNum() . "wincmd w")
     call b:NERDTree.root.refresh()
     call b:NERDTree.render()
-    call nerdtree#redraw(0)
+    redraw
     call nerdtree#exec(l:curWin . "wincmd w")
     call nerdtree#echo("")
 endfunction

--- a/lib/nerdtree/menu_controller.vim
+++ b/lib/nerdtree/menu_controller.vim
@@ -31,7 +31,11 @@ function! s:MenuController.showMenu()
         let l:done = 0
 
         while !l:done
-            mode
+            if has('nvim')
+                mode
+            else
+                redraw!
+            endif
             call self._echoPrompt()
 
             let l:key = nr2char(getchar())

--- a/lib/nerdtree/menu_controller.vim
+++ b/lib/nerdtree/menu_controller.vim
@@ -31,7 +31,7 @@ function! s:MenuController.showMenu()
         let l:done = 0
 
         while !l:done
-            call nerdtree#redraw(1)
+            mode
             call self._echoPrompt()
 
             let l:key = nr2char(getchar())
@@ -42,7 +42,7 @@ function! s:MenuController.showMenu()
 
         " Redraw when "Ctrl-C" or "Esc" is received.
         if !l:done || self.selection == -1
-            call nerdtree#redraw(1)
+            redraw!
         endif
     endtry
 

--- a/lib/nerdtree/menu_controller.vim
+++ b/lib/nerdtree/menu_controller.vim
@@ -68,7 +68,7 @@ function! s:MenuController._echoPrompt()
 
         echo "Menu: [" . join(shortcuts, ",") . "] (" . navHelp . " or shortcut): "
     else
-        echo "NERDTree Menu. " . navHelp . " . or the shortcuts indicated"
+        echo "NERDTree Menu. " . navHelp . ", or the shortcuts indicated"
         echo "========================================================="
 
         for i in range(0, len(self.menuItems)-1)

--- a/nerdtree_plugin/fs_menu.vim
+++ b/nerdtree_plugin/fs_menu.vim
@@ -78,7 +78,7 @@ function! s:inputPrompt(action)
     endif
 
     if g:NERDTreeMenuController.isMinimal()
-        call nerdtree#redraw(1) " Clear the menu
+        redraw! " Clear the menu
         return minimal . " "
     else
         let divider = "=========================================================="
@@ -185,7 +185,7 @@ function! NERDTreeAddNode()
             call newTreeNode.putCursorHere(1, 0)
         endif
 
-        call nerdtree#redraw(1)
+        redraw!
     catch /^NERDTree/
         call nerdtree#echoWarning("Node Not Created.")
     endtry
@@ -234,7 +234,7 @@ function! NERDTreeMoveNode()
 
         call curNode.putCursorHere(1, 0)
 
-        call nerdtree#redraw(1)
+        redraw!
     catch /^NERDTree/
         call nerdtree#echoWarning("Node Not Renamed.")
     endtry
@@ -272,7 +272,7 @@ function! NERDTreeDeleteNode()
                 call s:promptToDelBuffer(bufnum, prompt)
             endif
 
-            call nerdtree#redraw(1)
+            redraw!
         catch /^NERDTree/
             call nerdtree#echoWarning("Could not remove node")
         endtry
@@ -362,7 +362,7 @@ function! NERDTreeCopyNode()
         call nerdtree#echo("Copy aborted.")
     endif
     let &shellslash = l:shellslash
-    call nerdtree#redraw(1)
+    redraw!
 endfunction
 
 " FUNCTION: NERDTreeCopyPath() {{{1


### PR DESCRIPTION
### Description of Changes
Closes #1020. 

Revert #1019, which too liberally used the `:mode` command in Neovim. This resulted in excessive flickering of the screen. It also caused artifacts on the screen, which ironically were cleared by manually issuing the `:mode` command.

---
### New Version Info

- [x] Derive a new version number. Increment the:
    - [ ] `MAJOR` version when you make incompatible API changes
    - [ ] `MINOR` version when you add functionality in a backwards-compatible manner
    - [x] `PATCH` version when you make backwards-compatible bug fixes
- [x] Update [CHANGELOG.md](https://github.com/scrooloose/nerdtree/blob/master/CHANGELOG.md), following this format/example:
    ```
    #### MAJOR.MINOR...
    - **.PATCH**: PR Title (Author) [#PR Number](link to PR)

    #### 5.1...
    - **.1**: Update Changelog and create PR Template (PhilRunninger) [#1007](https://github.com/scrooloose/nerdtree/pull/1007)
    - **.0**: Too many changes for one patch...
    ```