### PR TITLE
Suppress events for intermediate window/tab/buffer changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 
 #### 5.2...
+- **.7**: Suppress events for intermediate window/tab/buffer changes [#1026](https://github.com/scrooloose/nerdtree/pull/1026)
 - **.6**: In CHANGELOG.md and PR template, make reference to PR a true HTML link. [#1017](https://github.com/scrooloose/nerdtree/pull/1017)
 - **.5**: Use `:mode` instead of `:redraw!` when updating menu. (PhilRunninger) [#1016](https://github.com/scrooloose/nerdtree/pull/1016)
 - **.4**: When searching for root line num, stop at end of file. (PhilRunninger) [#1015](https://github.com/scrooloose/nerdtree/pull/1015)

--- a/autoload/nerdtree.vim
+++ b/autoload/nerdtree.vim
@@ -154,13 +154,17 @@ function! nerdtree#deprecated(func, ...)
     endif
 endfunction
 
-" FUNCTION: nerdtree#exec(cmd) {{{2
+" FUNCTION: nerdtree#exec(cmd, [ignoreAll]) {{{2
 " Same as :exec cmd but with eventignore set for the duration
 " to disable the autocommands used by NERDTree (BufEnter,
 " BufLeave and VimEnter)
-function! nerdtree#exec(cmd)
+function! nerdtree#exec(cmd, ...)
     let old_ei = &ei
-    set ei=BufEnter,BufLeave,VimEnter
+    if a:0 > 0
+        set ei=all
+    " else
+    "     set ei=BufEnter,BufLeave,VimEnter
+    endif
     exec a:cmd
     let &ei = old_ei
 endfunction

--- a/autoload/nerdtree.vim
+++ b/autoload/nerdtree.vim
@@ -157,12 +157,9 @@ endfunction
 " FUNCTION: nerdtree#exec(cmd, ignoreAll) {{{2
 " Same as :exec cmd but, if ignoreAll is TRUE, set eventignore=all for the duration
 function! nerdtree#exec(cmd, ignoreAll)
-    " call writefile([strftime("%F %T").','.a:cmd.','.(a:0>0).','.bufname("")], expand("~/.vim/NT588.log"),"a")
     let old_ei = &ei
     if a:ignoreAll
         set ei=all
-    " else
-    "     set ei=BufEnter,BufLeave,VimEnter
     endif
     exec a:cmd
     let &ei = old_ei

--- a/autoload/nerdtree.vim
+++ b/autoload/nerdtree.vim
@@ -154,13 +154,12 @@ function! nerdtree#deprecated(func, ...)
     endif
 endfunction
 
-" FUNCTION: nerdtree#exec(cmd, [ignoreAll]) {{{2
-" Same as :exec cmd but with eventignore set for the duration
-" to disable the autocommands used by NERDTree (BufEnter,
-" BufLeave and VimEnter)
-function! nerdtree#exec(cmd, ...)
+" FUNCTION: nerdtree#exec(cmd, ignoreAll) {{{2
+" Same as :exec cmd but, if ignoreAll is TRUE, set eventignore=all for the duration
+function! nerdtree#exec(cmd, ignoreAll)
+    " call writefile([strftime("%F %T").','.a:cmd.','.(a:0>0).','.bufname("")], expand("~/.vim/NT588.log"),"a")
     let old_ei = &ei
-    if a:0 > 0
+    if a:ignoreAll
         set ei=all
     " else
     "     set ei=BufEnter,BufLeave,VimEnter

--- a/autoload/nerdtree/ui_glue.vim
+++ b/autoload/nerdtree/ui_glue.vim
@@ -574,11 +574,11 @@ function! s:refreshRoot()
     call nerdtree#echo("Refreshing the root node. This could take a while...")
 
     let l:curWin = winnr()
-    call nerdtree#exec(g:NERDTree.GetWinNum() . "wincmd w")
+    call nerdtree#exec(g:NERDTree.GetWinNum() . "wincmd w", 1)
     call b:NERDTree.root.refresh()
     call b:NERDTree.render()
     redraw
-    call nerdtree#exec(l:curWin . "wincmd w")
+    call nerdtree#exec(l:curWin . "wincmd w", 1)
     call nerdtree#echo("")
 endfunction
 

--- a/lib/nerdtree/bookmark.vim
+++ b/lib/nerdtree/bookmark.vim
@@ -159,8 +159,8 @@ endfunction
 " FUNCTION: s:Edit() {{{1
 " opens the NERDTreeBookmarks file for manual editing
 function! s:Bookmark.Edit()
-    execute "wincmd w"
-    execute "edit ".g:NERDTreeBookmarksFile
+    call nerdtree#exec("wincmd w",1)
+    call nerdtree#exec("edit ".g:NERDTreeBookmarksFile, 1)
 endfunction
 
 " FUNCTION: Bookmark.getNode(nerdtree, searchFromAbsoluteRoot) {{{1

--- a/lib/nerdtree/bookmark.vim
+++ b/lib/nerdtree/bookmark.vim
@@ -159,7 +159,7 @@ endfunction
 " FUNCTION: s:Edit() {{{1
 " opens the NERDTreeBookmarks file for manual editing
 function! s:Bookmark.Edit()
-    call nerdtree#exec("wincmd w",1)
+    call nerdtree#exec("wincmd w", 1)
     call nerdtree#exec("edit ".g:NERDTreeBookmarksFile, 1)
 endfunction
 

--- a/lib/nerdtree/nerdtree.vim
+++ b/lib/nerdtree/nerdtree.vim
@@ -44,14 +44,14 @@ function! s:NERDTree.Close()
         let l:useWinId = exists('*win_getid') && exists('*win_gotoid')
 
         if winnr() == s:NERDTree.GetWinNum()
-            call nerdtree#exec("wincmd p")
+            call nerdtree#exec("wincmd p", 1)
             let l:activeBufOrWin = l:useWinId ? win_getid() : bufnr("")
-            call nerdtree#exec("wincmd p")
+            call nerdtree#exec("wincmd p", 1)
         else
             let l:activeBufOrWin = l:useWinId ? win_getid() : bufnr("")
         endif
 
-        call nerdtree#exec(s:NERDTree.GetWinNum() . " wincmd w")
+        call nerdtree#exec(s:NERDTree.GetWinNum() . " wincmd w", 1)
         close
         if l:useWinId
             call nerdtree#exec("call win_gotoid(" . l:activeBufOrWin . ")")
@@ -98,7 +98,7 @@ endfunction
 "Places the cursor in the nerd tree window
 function! s:NERDTree.CursorToTreeWin()
     call g:NERDTree.MustBeOpen()
-    call nerdtree#exec(g:NERDTree.GetWinNum() . "wincmd w")
+    call nerdtree#exec(g:NERDTree.GetWinNum() . "wincmd w", 1)
 endfunction
 
 " Function: s:NERDTree.ExistsForBuffer()   {{{1

--- a/lib/nerdtree/nerdtree.vim
+++ b/lib/nerdtree/nerdtree.vim
@@ -52,7 +52,7 @@ function! s:NERDTree.Close()
         endif
 
         call nerdtree#exec(s:NERDTree.GetWinNum() . " wincmd w", 1)
-        close
+        call nerdtree#exec("close", 1)
         if l:useWinId
             call nerdtree#exec("call win_gotoid(" . l:activeBufOrWin . ")",0)
         else

--- a/lib/nerdtree/nerdtree.vim
+++ b/lib/nerdtree/nerdtree.vim
@@ -54,9 +54,9 @@ function! s:NERDTree.Close()
         call nerdtree#exec(s:NERDTree.GetWinNum() . " wincmd w", 1)
         close
         if l:useWinId
-            call nerdtree#exec("call win_gotoid(" . l:activeBufOrWin . ")")
+            call nerdtree#exec("call win_gotoid(" . l:activeBufOrWin . ")",0)
         else
-            call nerdtree#exec(bufwinnr(l:activeBufOrWin) . " wincmd w")
+            call nerdtree#exec(bufwinnr(l:activeBufOrWin) . " wincmd w",0)
         endif
     else
         close

--- a/lib/nerdtree/nerdtree.vim
+++ b/lib/nerdtree/nerdtree.vim
@@ -54,9 +54,9 @@ function! s:NERDTree.Close()
         call nerdtree#exec(s:NERDTree.GetWinNum() . " wincmd w", 1)
         call nerdtree#exec("close", 1)
         if l:useWinId
-            call nerdtree#exec("call win_gotoid(" . l:activeBufOrWin . ")",0)
+            call nerdtree#exec("call win_gotoid(" . l:activeBufOrWin . ")", 0)
         else
-            call nerdtree#exec(bufwinnr(l:activeBufOrWin) . " wincmd w",0)
+            call nerdtree#exec(bufwinnr(l:activeBufOrWin) . " wincmd w", 0)
         endif
     else
         close

--- a/lib/nerdtree/opener.vim
+++ b/lib/nerdtree/opener.vim
@@ -220,7 +220,7 @@ function! s:Opener._newVSplit()
     endif
 
     call nerdtree#exec('wincmd p', 1)
-    vnew
+    call nerdtree#exec('vnew', 1)
 
     let l:currentWindowNumber = winnr()
 

--- a/lib/nerdtree/opener.vim
+++ b/lib/nerdtree/opener.vim
@@ -203,7 +203,7 @@ function! s:Opener._newSplit()
         let size = exists("b:NERDTreeOldWindowSize") ? b:NERDTreeOldWindowSize : g:NERDTreeWinSize
         call nerdtree#exec(there, 1)
         exec("silent ". splitMode ." resize ". size)
-        call nerdtree#exec('wincmd p',0)
+        call nerdtree#exec('wincmd p', 0)
     endif
 
     " Restore splitmode settings
@@ -228,7 +228,7 @@ function! s:Opener._newVSplit()
     call g:NERDTree.CursorToTreeWin()
     execute 'silent vertical resize ' . l:winwidth
 
-    call nerdtree#exec(l:currentWindowNumber . 'wincmd w',0)
+    call nerdtree#exec(l:currentWindowNumber . 'wincmd w', 0)
 endfunction
 
 " FUNCTION: Opener.open(target) {{{1
@@ -321,7 +321,7 @@ function! s:Opener._reuseWindow()
     "check the current tab for the window
     let winnr = bufwinnr('^' . self._path.str() . '$')
     if winnr != -1
-        call nerdtree#exec(winnr . "wincmd w",0)
+        call nerdtree#exec(winnr . "wincmd w", 0)
         call self._checkToCloseTree(0)
         return 1
     endif
@@ -336,7 +336,7 @@ function! s:Opener._reuseWindow()
         call self._checkToCloseTree(1)
         call nerdtree#exec(tabnr . 'tabnext', 1)
         let winnr = bufwinnr('^' . self._path.str() . '$')
-        call nerdtree#exec(winnr . "wincmd w",0)
+        call nerdtree#exec(winnr . "wincmd w", 0)
         return 1
     endif
 

--- a/lib/nerdtree/opener.vim
+++ b/lib/nerdtree/opener.vim
@@ -203,7 +203,7 @@ function! s:Opener._newSplit()
         let size = exists("b:NERDTreeOldWindowSize") ? b:NERDTreeOldWindowSize : g:NERDTreeWinSize
         call nerdtree#exec(there, 1)
         exec("silent ". splitMode ." resize ". size)
-        call nerdtree#exec('wincmd p')
+        call nerdtree#exec('wincmd p',0)
     endif
 
     " Restore splitmode settings
@@ -228,7 +228,7 @@ function! s:Opener._newVSplit()
     call g:NERDTree.CursorToTreeWin()
     execute 'silent vertical resize ' . l:winwidth
 
-    call nerdtree#exec(l:currentWindowNumber . 'wincmd w')
+    call nerdtree#exec(l:currentWindowNumber . 'wincmd w',0)
 endfunction
 
 " FUNCTION: Opener.open(target) {{{1
@@ -321,7 +321,7 @@ function! s:Opener._reuseWindow()
     "check the current tab for the window
     let winnr = bufwinnr('^' . self._path.str() . '$')
     if winnr != -1
-        call nerdtree#exec(winnr . "wincmd w")
+        call nerdtree#exec(winnr . "wincmd w",0)
         call self._checkToCloseTree(0)
         return 1
     endif
@@ -336,7 +336,7 @@ function! s:Opener._reuseWindow()
         call self._checkToCloseTree(1)
         call nerdtree#exec(tabnr . 'tabnext', 1)
         let winnr = bufwinnr('^' . self._path.str() . '$')
-        call nerdtree#exec(winnr . "wincmd w")
+        call nerdtree#exec(winnr . "wincmd w",0)
         return 1
     endif
 

--- a/lib/nerdtree/opener.vim
+++ b/lib/nerdtree/opener.vim
@@ -107,10 +107,10 @@ function! s:Opener._isWindowUsable(winnumber)
     endif
 
     let oldwinnr = winnr()
-    call nerdtree#exec(a:winnumber . "wincmd p")
+    call nerdtree#exec(a:winnumber . "wincmd p", 1)
     let specialWindow = getbufvar("%", '&buftype') != '' || getwinvar('%', '&previewwindow')
     let modified = &modified
-    call nerdtree#exec(oldwinnr . "wincmd p")
+    call nerdtree#exec(oldwinnr . "wincmd p", 1)
 
     "if its a special window e.g. quickfix or another explorer plugin then we
     "have to split
@@ -172,7 +172,7 @@ function! s:Opener._newSplit()
     let below=0
 
     " Attempt to go to adjacent window
-    call nerdtree#exec(back)
+    call nerdtree#exec(back, 1)
 
     let onlyOneWin = (winnr("$") ==# 1)
 
@@ -201,7 +201,7 @@ function! s:Opener._newSplit()
     "resize the tree window if no other window was open before
     if onlyOneWin
         let size = exists("b:NERDTreeOldWindowSize") ? b:NERDTreeOldWindowSize : g:NERDTreeWinSize
-        call nerdtree#exec(there)
+        call nerdtree#exec(there, 1)
         exec("silent ". splitMode ." resize ". size)
         call nerdtree#exec('wincmd p')
     endif
@@ -219,7 +219,7 @@ function! s:Opener._newVSplit()
         let l:winwidth = g:NERDTreeWinSize
     endif
 
-    call nerdtree#exec('wincmd p')
+    call nerdtree#exec('wincmd p', 1)
     vnew
 
     let l:currentWindowNumber = winnr()
@@ -290,9 +290,9 @@ function! s:Opener._previousWindow()
     else
         try
             if !self._isWindowUsable(winnr("#"))
-                call nerdtree#exec(self._firstUsableWindow() . "wincmd w")
+                call nerdtree#exec(self._firstUsableWindow() . "wincmd w", 1)
             else
-                call nerdtree#exec('wincmd p')
+                call nerdtree#exec('wincmd p', 1)
             endif
         catch /^Vim\%((\a\+)\)\=:E37/
             call g:NERDTree.CursorToTreeWin()
@@ -305,8 +305,8 @@ endfunction
 
 " FUNCTION: Opener._restoreCursorPos() {{{1
 function! s:Opener._restoreCursorPos()
-    call nerdtree#exec(self._tabnr . 'tabnext')
-    call nerdtree#exec(bufwinnr(self._bufnr) . 'wincmd w')
+    call nerdtree#exec(self._tabnr . 'tabnext', 1)
+    call nerdtree#exec(bufwinnr(self._bufnr) . 'wincmd w', 1)
 endfunction
 
 " FUNCTION: Opener._reuseWindow() {{{1
@@ -334,7 +334,7 @@ function! s:Opener._reuseWindow()
     let tabnr = self._path.tabnr()
     if tabnr
         call self._checkToCloseTree(1)
-        call nerdtree#exec(tabnr . 'tabnext')
+        call nerdtree#exec(tabnr . 'tabnext', 1)
         let winnr = bufwinnr('^' . self._path.str() . '$')
         call nerdtree#exec(winnr . "wincmd w")
         return 1

--- a/lib/nerdtree/ui.vim
+++ b/lib/nerdtree/ui.vim
@@ -360,7 +360,7 @@ function! s:UI.saveScreenState()
     let self._screenState['oldPos'] = getpos(".")
     let self._screenState['oldTopLine'] = line("w0")
     let self._screenState['oldWindowSize']= winwidth("")
-    call nerdtree#exec(win . "wincmd w")
+    call nerdtree#exec(win . "wincmd w", 1)
 endfunction
 
 " FUNCTION: s:UI.setShowHidden(val) {{{1

--- a/lib/nerdtree/ui.vim
+++ b/lib/nerdtree/ui.vim
@@ -506,10 +506,10 @@ endfunction
 function! s:UI.toggleZoom()
     if exists("b:NERDTreeZoomed") && b:NERDTreeZoomed
         let size = exists("b:NERDTreeOldWindowSize") ? b:NERDTreeOldWindowSize : g:NERDTreeWinSize
-        call nerdtree#exec("silent vertical resize ". size,1)
+        call nerdtree#exec("silent vertical resize ". size, 1)
         let b:NERDTreeZoomed = 0
     else
-        call nerdtree#exec("vertical resize ". get(g:, 'NERDTreeWinSizeMax', ''),1)
+        call nerdtree#exec("vertical resize ". get(g:, 'NERDTreeWinSizeMax', ''), 1)
         let b:NERDTreeZoomed = 1
     endif
 endfunction

--- a/lib/nerdtree/ui.vim
+++ b/lib/nerdtree/ui.vim
@@ -340,7 +340,7 @@ function! s:UI.restoreScreenState()
     if !has_key(self, '_screenState')
         return
     endif
-    exec("silent vertical resize " . self._screenState['oldWindowSize'])
+    call nerdtree#exec("silent vertical resize " . self._screenState['oldWindowSize'], 1)
 
     let old_scrolloff=&scrolloff
     let &scrolloff=0
@@ -506,10 +506,10 @@ endfunction
 function! s:UI.toggleZoom()
     if exists("b:NERDTreeZoomed") && b:NERDTreeZoomed
         let size = exists("b:NERDTreeOldWindowSize") ? b:NERDTreeOldWindowSize : g:NERDTreeWinSize
-        exec "silent vertical resize ". size
+        call nerdtree#exec("silent vertical resize ". size,1)
         let b:NERDTreeZoomed = 0
     else
-        exec "vertical resize ". get(g:, 'NERDTreeWinSizeMax', '')
+        call nerdtree#exec("vertical resize ". get(g:, 'NERDTreeWinSizeMax', ''),1)
         let b:NERDTreeZoomed = 1
     endif
 endfunction

--- a/nerdtree_plugin/fs_menu.vim
+++ b/nerdtree_plugin/fs_menu.vim
@@ -114,12 +114,12 @@ function! s:promptToDelBuffer(bufnum, msg)
             let l:listedBufferCount = 0
         endif
         if l:listedBufferCount > 1
-            call nerdtree#exec("tabdo windo if winbufnr(0) == " . a:bufnum . " | exec ':bnext! ' | endif",1)
+            call nerdtree#exec("tabdo windo if winbufnr(0) == " . a:bufnum . " | exec ':bnext! ' | endif", 1)
         else
-            call nerdtree#exec("tabdo windo if winbufnr(0) == " . a:bufnum . " | exec ':enew! ' | endif",1)
+            call nerdtree#exec("tabdo windo if winbufnr(0) == " . a:bufnum . " | exec ':enew! ' | endif", 1)
         endif
-        call nerdtree#exec("tabnext " . s:originalTabNumber,1)
-        call nerdtree#exec(s:originalWindowNumber . "wincmd w",1)
+        call nerdtree#exec("tabnext " . s:originalTabNumber, 1)
+        call nerdtree#exec(s:originalWindowNumber . "wincmd w", 1)
         " 3. We don't need a previous buffer anymore
         call nerdtree#exec("bwipeout! " . a:bufnum, 0)
     endif
@@ -141,7 +141,7 @@ function! s:renameBuffer(bufNum, newNodeName, isDirectory)
         let editStr = g:NERDTreePath.New(a:newNodeName).str({'format': 'Edit'})
     endif
     " 1. ensure that a new buffer is loaded
-    call nerdtree#exec("badd " . quotedFileName,1)
+    call nerdtree#exec("badd " . quotedFileName, 1)
     " 2. ensure that all windows which display the just deleted filename
     " display a buffer for a new filename.
     let s:originalTabNumber = tabpagenr()

--- a/nerdtree_plugin/fs_menu.vim
+++ b/nerdtree_plugin/fs_menu.vim
@@ -114,14 +114,14 @@ function! s:promptToDelBuffer(bufnum, msg)
             let l:listedBufferCount = 0
         endif
         if l:listedBufferCount > 1
-            exec "tabdo windo if winbufnr(0) == " . a:bufnum . " | exec ':bnext! ' | endif"
+            call nerdtree#exec("tabdo windo if winbufnr(0) == " . a:bufnum . " | exec ':bnext! ' | endif",1)
         else
-            exec "tabdo windo if winbufnr(0) == " . a:bufnum . " | exec ':enew! ' | endif"
+            call nerdtree#exec("tabdo windo if winbufnr(0) == " . a:bufnum . " | exec ':enew! ' | endif",1)
         endif
-        exec "tabnext " . s:originalTabNumber
-        exec s:originalWindowNumber . "wincmd w"
+        call nerdtree#exec("tabnext " . s:originalTabNumber,1)
+        call nerdtree#exec(s:originalWindowNumber . "wincmd w",1)
         " 3. We don't need a previous buffer anymore
-        exec "bwipeout! " . a:bufnum
+        call nerdtree#exec("bwipeout! " . a:bufnum, 0)
     endif
 endfunction
 
@@ -141,17 +141,17 @@ function! s:renameBuffer(bufNum, newNodeName, isDirectory)
         let editStr = g:NERDTreePath.New(a:newNodeName).str({'format': 'Edit'})
     endif
     " 1. ensure that a new buffer is loaded
-    exec "badd " . quotedFileName
+    call nerdtree#exec("badd " . quotedFileName,1)
     " 2. ensure that all windows which display the just deleted filename
     " display a buffer for a new filename.
     let s:originalTabNumber = tabpagenr()
     let s:originalWindowNumber = winnr()
-    exec "tabdo windo if winbufnr(0) == " . a:bufNum . " | exec ':e! " . editStr . "' | endif"
-    exec "tabnext " . s:originalTabNumber
-    exec s:originalWindowNumber . "wincmd w"
+    call nerdtree#exec("tabdo windo if winbufnr(0) == " . a:bufNum . " | exec ':e! " . editStr . "' | endif", 1)
+    call nerdtree#exec("tabnext " . s:originalTabNumber, 1)
+    call nerdtree#exec(s:originalWindowNumber . "wincmd w", 1)
     " 3. We don't need a previous buffer anymore
     try
-        exec "confirm bwipeout " . a:bufNum
+        call nerdtree#exec("confirm bwipeout " . a:bufNum, 0)
     catch
         " This happens when answering Cancel if confirmation is needed. Do nothing.
     endtry


### PR DESCRIPTION
### Description of Changes
Closes #588   <!-- Issue number this PR addresses. If none, remove this line. -->

Got rid of the line that always ignores the `BufEnter`, `BufLeave`, and `VimEnter` events. So now, no events are ignored, and this allows `BufEnter` to be fired when opening an already open file, fixing #588.

But not so fast.....

Closes #684 

The change above causes events to be fired way more often than necessary because of NERDTree's need to switch windows at various times. To solve this, a new parameter was added to `nerdtree#exec()` that can cause **all** events to be ignored. This is set to 1 for all the intermediate window switches, and then to 0 for the final window switch to the selected file. This change, which comprises many lines of code throughout NERDTree, fixes the ping-ponging that was mentioned in #684 but has, until now, been left unaddressed.

---
### New Version Info

- [x] Derive a new version number. Increment the:
    - [ ] `MAJOR` version when you make incompatible API changes
    - [ ] `MINOR` version when you add functionality in a backwards-compatible manner
    - [x] `PATCH` version when you make backwards-compatible bug fixes
- [x] Update [CHANGELOG.md](https://github.com/scrooloose/nerdtree/blob/master/CHANGELOG.md), following this format/example:
    ```
    #### MAJOR.MINOR...
    - **.PATCH**: PR Title (Author) [#PR Number](link to PR)

    #### 5.1...
    - **.1**: Update Changelog and create PR Template (PhilRunninger) [#1007](https://github.com/scrooloose/nerdtree/pull/1007)
    - **.0**: Too many changes for one patch...
    ```
