### PR TITLE
Make the behavior of window splits consistent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Change Log
 
+#### 6.0...
+- **.0**: Make the behavior of window splits consistent [#1035](https://github.com/scrooloose/nerdtree/pull/1035)
 #### 5.3...
 - **.1**: Fix the `e` key mapping to use netrw if desired [#1031](https://github.com/scrooloose/nerdtree/pull/1031)
 - **.0**: Add file extension and size to sorting capabilities [#1029](https://github.com/scrooloose/nerdtree/pull/1029)

--- a/autoload/nerdtree.vim
+++ b/autoload/nerdtree.vim
@@ -4,6 +4,11 @@ endif
 let g:loaded_nerdtree_autoload = 1
 
 let s:rootNERDTreePath = resolve(expand("<sfile>:p:h:h"))
+
+"FUNCTION: nerdtree#version(...) {{{1
+"  If any value is given as an argument, the entire line of text from the
+"  change log is shown for the current version; otherwise, only the version
+"  number is shown.
 function! nerdtree#version(...)
     let l:changelog = readfile(join([s:rootNERDTreePath, "CHANGELOG.md"], nerdtree#slash()))
     let l:text = 'Unknown'
@@ -22,6 +27,7 @@ endfunction
 " SECTION: General Functions {{{1
 "============================================================
 
+"FUNCTION: nerdtree#slash() {{{2
 function! nerdtree#slash()
 
     if nerdtree#runningWindows()
@@ -49,7 +55,6 @@ function! nerdtree#and(x,y)
             if (l:x % 2) && (l:y % 2)
                 let l:result += float2nr(pow(2, l:n))
             endif
-            echomsg l:x . ", " . l:y . " => " l:result
             let l:x = float2nr(l:x / 2)
             let l:y = float2nr(l:y / 2)
             let l:n += 1

--- a/lib/nerdtree/nerdtree.vim
+++ b/lib/nerdtree/nerdtree.vim
@@ -148,12 +148,19 @@ function! s:NERDTree.GetWinNum()
         return bufwinnr(t:NERDTreeBufName)
     endif
 
+    " If WindowTree, there is no t:NERDTreeBufName variable. Search all windows.
+    for w in range(1,winnr('$'))
+        if bufname(winbufnr(w)) =~# '^' . g:NERDTreeCreator.BufNamePrefix() . '\d\+$'
+            return w
+        endif
+    endfor
+
     return -1
 endfunction
 
 "FUNCTION: s:NERDTree.IsOpen() {{{1
 function! s:NERDTree.IsOpen()
-    return s:NERDTree.GetWinNum() != -1 || bufname('%') =~# '^' . g:NERDTreeCreator.BufNamePrefix() . '\d\+$'
+    return s:NERDTree.GetWinNum() != -1
 endfunction
 
 "FUNCTION: s:NERDTree.isTabTree() {{{1

--- a/lib/nerdtree/opener.vim
+++ b/lib/nerdtree/opener.vim
@@ -153,53 +153,15 @@ endfunction
 
 " FUNCTION: Opener._newSplit() {{{1
 function! s:Opener._newSplit()
-    " Save the user's settings for splitbelow and splitright
-    let savesplitbelow=&splitbelow
-    let savesplitright=&splitright
-
-    " 'there' will be set to a command to move from the split window
-    " back to the explorer window
-    "
-    " 'back' will be set to a command to move from the explorer window
-    " back to the newly split window
-    "
-    " 'right' and 'below' will be set to the settings needed for
-    " splitbelow and splitright IF the explorer is the only window.
-    "
-    let there= g:NERDTreeWinPos ==# "left" ? "wincmd h" : "wincmd l"
-    let back = g:NERDTreeWinPos ==# "left" ? "wincmd l" : "wincmd h"
-    let right= g:NERDTreeWinPos ==# "left"
-    let below=0
-
     let onlyOneWin = (winnr("$") ==# 1)
-
-    " Special case when multiple window exists and user prefers to
-    " split relative to the previous window
-    if !onlyOneWin && exists('g:NERDTreeSplitFromPreviousWindow')
-                \ && g:NERDTreeSplitFromPreviousWindow == 1
-        let back = "wincmd p"
-    endif
-
-    echom back
-    " Attempt to go to adjacent window
-    call nerdtree#exec(back, 1)
-
-
-    " If no adjacent window, set splitright and splitbelow appropriately
-    if onlyOneWin
-        let &splitright=right
-        let &splitbelow=below
-    else
-        " found adjacent window - invert split direction
-        let &splitright=!right
-        let &splitbelow=!below
-    endif
-
-    let splitMode = onlyOneWin ? "vertical" : ""
+    let savesplitright = &splitright
+    let &splitright = onlyOneWin ?  (g:NERDTreeWinPos ==# "left") : (g:NERDTreeWinPos !=# "left")
 
     " Open the new window
     try
-        exec(splitMode." sp ")
+        call nerdtree#exec('wincmd p', 1)
+        " If only one window (ie. NERDTree), split vertically instead.
+        call nerdtree#exec(onlyOneWin ? "vertical split" : "split",1)
     catch /^Vim\%((\a\+)\)\=:E37/
         call g:NERDTree.CursorToTreeWin()
         throw "NERDTree.FileAlreadyOpenAndModifiedError: ". self._path.str() ." is already open and modified."
@@ -209,14 +171,12 @@ function! s:Opener._newSplit()
 
     "resize the tree window if no other window was open before
     if onlyOneWin
-        let size = exists("b:NERDTreeOldWindowSize") ? b:NERDTreeOldWindowSize : g:NERDTreeWinSize
-        call nerdtree#exec(there, 1)
-        exec("silent ". splitMode ." resize ". size)
+        let size = exists('b:NERDTreeOldWindowSize') ? b:NERDTreeOldWindowSize : g:NERDTreeWinSize
+        call nerdtree#exec('wincmd p', 1)
+        call nerdtree#exec('silent '. splitMode .' resize '. size, 1)
         call nerdtree#exec('wincmd p', 0)
     endif
 
-    " Restore splitmode settings
-    let &splitbelow=savesplitbelow
     let &splitright=savesplitright
 endfunction
 

--- a/lib/nerdtree/opener.vim
+++ b/lib/nerdtree/opener.vim
@@ -71,9 +71,9 @@ endfunction
 function! s:Opener._gotoTargetWin()
     if b:NERDTree.isWinTree()
         if self._where == 'v'
-            vsplit
+            call self._newVSplit()
         elseif self._where == 'h'
-            split
+            call self._newSplit()
         elseif self._where == 't'
             tabnew
         endif
@@ -155,7 +155,9 @@ endfunction
 function! s:Opener._newSplit()
     let onlyOneWin = (winnr("$") ==# 1)
     let savesplitright = &splitright
-    let &splitright = onlyOneWin ?  (g:NERDTreeWinPos ==# "left") : (g:NERDTreeWinPos !=# "left")
+    if onlyOneWin
+        let &splitright = (g:NERDTreeWinPos ==# "left")
+    endif
 
     " Open the new window
     try
@@ -184,7 +186,10 @@ endfunction
 function! s:Opener._newVSplit()
     let l:winwidth = winwidth('.')
 
-    if winnr('$') == 1
+    let onlyOneWin = (winnr("$") ==# 1)
+    let savesplitright = &splitright
+    if onlyOneWin
+        let &splitright = (g:NERDTreeWinPos ==# "left")
         let l:winwidth = g:NERDTreeWinSize
     endif
 
@@ -198,6 +203,7 @@ function! s:Opener._newVSplit()
     execute 'silent vertical resize ' . l:winwidth
 
     call nerdtree#exec(l:currentWindowNumber . 'wincmd w', 0)
+    let &splitright=savesplitright
 endfunction
 
 " FUNCTION: Opener.open(target) {{{1


### PR DESCRIPTION
### Description of Changes
Closes #941  <!-- Issue number this PR addresses. If none, remove this line. -->
This PR addresses changes requested for #941, and expands on the work started there.

Closes #327 
This PR forces NERDTree to respect the user's values for the `splitright` and `splitbelow` settings, and the `g:NERDTreeWinPos` variable. This changes the current behavior of the splits opened by NERDTree, so this will be a new MAJOR release - 6.0.0. The changes are as follows:

1. The window to be split will **always** be the previous window. This could be the one where `:NERDTree` (or `:NERDTreeFocus` or `:NERDTreeToggle`) was invoked. Or maybe a window command (such as `10<C-W>h`) was used to jump directly to the NERDTree window. When in doubt, you can use the `<C-W>p` command to jump between the previous and current windows.
1. The `g:NERDTreeWinPos` variable will **always** be respected. This pertains to a NERDTree created when `g:NERDTreeHijackNetrw` is 1, and Vim is invoked with a directory, as in `vim .`. When splitting the window multiple times in this scenario, NERDTree will stay full-height on the desired side of the screen.
1. The vim setting `splitright` will be be respected. When performing a vertical split (`s` or `gs`), the previous window will be split to the right (`splitright`) or left (`nosplitright`) as directed by the user's setting.
1. The vim setting `splitbelow` will be be respected. When performing a horizontal split (`i` or `gi`), the previous window will be split above (`nosplitbelow`) or below (`splitbelow`) as directed by the user's setting.

These changes bring consistency to the NERDTree split commands, which previously had worked differently for vertical vs horizontal splitting.

---
### New Version Info

- [x] Derive a new version number. Increment the:
    - [x] `MAJOR` version when you make incompatible API changes
    - [ ] `MINOR` version when you add functionality in a backwards-compatible manner
    - [ ] `PATCH` version when you make backwards-compatible bug fixes
- [x] Update [CHANGELOG.md](https://github.com/scrooloose/nerdtree/blob/master/CHANGELOG.md), following the established pattern.
- [ ] Tag the merge commit, e.g. `git tag -a 3.1.4 -m "v3.1.4" && git push origin --tags`
  