### PR TITLE
Fix (p)ath not displaying in the minimal menu

### DIFF
--- a/lib/nerdtree/menu_controller.vim
+++ b/lib/nerdtree/menu_controller.vim
@@ -62,9 +62,10 @@ function! s:MenuController._echoPrompt()
 
     if self.isMinimal()
         let selection = self.menuItems[self.selection].text
+        let keyword = matchstr(selection, "\([^ ]*")
 
         let shortcuts = map(copy(self.menuItems), "v:val['shortcut']")
-        let shortcuts[self.selection] = " " . split(selection)[0] . " "
+        let shortcuts[self.selection] = " " . keyword . " "
 
         echo "Menu: [" . join(shortcuts, ",") . "] (" . navHelp . " or shortcut): "
     else


### PR DESCRIPTION
### Description of Changes

The ‘copy (p)ath to clipboard’ menu item was added
recently in this pull request:
https://github.com/scrooloose/nerdtree/pull/1002/files

However, this caused the NERDTreeMinimalMenu to
display ‘copy’ instead of ‘(p)ath’ because it was
simply using the first word of the item’s text.

This change fixes that bug by using a regex to
pick out the first word beginning with ‘(’

---
### New Version Info

- [ ] Derive a new version number. Increment the:
    - [ ] `MAJOR` version when you make incompatible API changes
    - [ ] `MINOR` version when you add functionality in a backwards-compatible manner
    - [ ] `PATCH` version when you make backwards-compatible bug fixes
- [ ] Update [CHANGELOG.md](https://github.com/scrooloose/nerdtree/blob/master/CHANGELOG.md), following the established pattern.
- [ ] Tag the merge commit, e.g. `git tag -a 3.1.4 -m "v3.1.4" && git push origin --tags`
