### PR TITLE
Reintroduce necessary variable mistakenly removed.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,18 @@
 # Change Log
 
 #### 6.0...
-- **.0**: Make the behavior of window splits consistent [#1035](https://github.com/scrooloose/nerdtree/pull/1035)
+- **.1**: Reintroduce necessary variable mistakenly removed. (PhilRunninger) [#1040](https://github.com/scrooloose/nerdtree/pull/1040)
+- **.0**: Make the behavior of window splits consistent (PhilRunninger) [#1035](https://github.com/scrooloose/nerdtree/pull/1035)
 #### 5.3...
-- **.3**: Fix (p)ath not displaying in the minimal menu [#1038](https://github.com/scrooloose/nerdtree/pull/1038)
-- **.2**: Enable events when closing NerdTree window. [#1037](https://github.com/scrooloose/nerdtree/pull/1037)
-- **.1**: Fix the `e` key mapping to use netrw if desired [#1031](https://github.com/scrooloose/nerdtree/pull/1031)
-- **.0**: Add file extension and size to sorting capabilities [#1029](https://github.com/scrooloose/nerdtree/pull/1029)
+- **.3**: Fix (p)ath not displaying in the minimal menu (tuzz) [#1038](https://github.com/scrooloose/nerdtree/pull/1038)
+- **.2**: Enable events when closing NerdTree window. (PhilRunninger) [#1037](https://github.com/scrooloose/nerdtree/pull/1037)
+- **.1**: Fix the `e` key mapping to use netrw if desired (PhilRunninger) [#1031](https://github.com/scrooloose/nerdtree/pull/1031)
+- **.0**: Add file extension and size to sorting capabilities (PhilRunninger) [#1029](https://github.com/scrooloose/nerdtree/pull/1029)
 #### 5.2...
-- **.9**: Suppress events for intermediate window/tab/buffer changes [#1026](https://github.com/scrooloose/nerdtree/pull/1026)
+- **.9**: Suppress events for intermediate window/tab/buffer changes (PhilRunninger) [#1026](https://github.com/scrooloose/nerdtree/pull/1026)
 - **.8**: Revert [#1019](https://github.com/scrooloose/nerdtree/pull/1019) to fix nvim artifacts and flickering. (PhilRunninger) [#1021](https://github.com/scrooloose/nerdtree/pull/1021)
-- **.7**: Use :mode only in neovim. MacVim still needs to use :redraw! [#1019](https://github.com/scrooloose/nerdtree/pull/1019)
-- **.6**: In CHANGELOG.md and PR template, make reference to PR a true HTML link. [#1017](https://github.com/scrooloose/nerdtree/pull/1017)
+- **.7**: Use :mode only in neovim. MacVim still needs to use :redraw! (PhilRunninger) [#1019](https://github.com/scrooloose/nerdtree/pull/1019)
+- **.6**: In CHANGELOG.md and PR template, make reference to PR a true HTML link. (PhilRunninger) [#1017](https://github.com/scrooloose/nerdtree/pull/1017)
 - **.5**: Use `:mode` instead of `:redraw!` when updating menu. (PhilRunninger) [#1016](https://github.com/scrooloose/nerdtree/pull/1016)
 - **.4**: When searching for root line num, stop at end of file. (PhilRunninger) [#1015](https://github.com/scrooloose/nerdtree/pull/1015)
 - **.3**: Fix `<CR>` key map on the bookmark (lkebin) [#1014](https://github.com/scrooloose/nerdtree/pull/1014)

--- a/lib/nerdtree/opener.vim
+++ b/lib/nerdtree/opener.vim
@@ -158,13 +158,13 @@ function! s:Opener._newSplit()
     if onlyOneWin
         let &splitright = (g:NERDTreeWinPos ==# "left")
     endif
+    " If only one window (ie. NERDTree), split vertically instead.
     let splitMode = onlyOneWin ? "vertical" : ""
 
     " Open the new window
     try
         call nerdtree#exec('wincmd p', 1)
-        " If only one window (ie. NERDTree), split vertically instead.
-        call nerdtree#exec(splitMode . "split",1)
+        call nerdtree#exec(splitMode . " split",1)
     catch /^Vim\%((\a\+)\)\=:E37/
         call g:NERDTree.CursorToTreeWin()
         throw "NERDTree.FileAlreadyOpenAndModifiedError: ". self._path.str() ." is already open and modified."

--- a/lib/nerdtree/opener.vim
+++ b/lib/nerdtree/opener.vim
@@ -158,12 +158,13 @@ function! s:Opener._newSplit()
     if onlyOneWin
         let &splitright = (g:NERDTreeWinPos ==# "left")
     endif
+    let splitMode = onlyOneWin ? "vertical" : ""
 
     " Open the new window
     try
         call nerdtree#exec('wincmd p', 1)
         " If only one window (ie. NERDTree), split vertically instead.
-        call nerdtree#exec(onlyOneWin ? "vertical split" : "split",1)
+        call nerdtree#exec(splitMode . "split",1)
     catch /^Vim\%((\a\+)\)\=:E37/
         call g:NERDTree.CursorToTreeWin()
         throw "NERDTree.FileAlreadyOpenAndModifiedError: ". self._path.str() ." is already open and modified."


### PR DESCRIPTION
### Description of Changes
Closes #1039   <!-- Issue number this PR addresses. If none, remove this line. -->

`let splitMode =...` was removed but is still needed in the 6.0.0 release. This PR adds it back in.

---
### New Version Info

- [x] Derive a new version number. Increment the:
    - [ ] `MAJOR` version when you make incompatible API changes
    - [ ] `MINOR` version when you add functionality in a backwards-compatible manner
    - [x] `PATCH` version when you make backwards-compatible bug fixes
- [x] Update [CHANGELOG.md](https://github.com/scrooloose/nerdtree/blob/master/CHANGELOG.md), following the established pattern.
- [ ] Tag the merge commit, e.g. `git tag -a 3.1.4 -m "v3.1.4" && git push origin --tags`
