### PR TITLE
Catch errors when trying to read CHANGELOG.md.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 
 #### 6.1...
+- **.1**: Catch errors when trying to read CHANGELOG.md. (PhilRunninger) [#1045](https://github.com/scrooloose/nerdtree/pull/1045)
 - **.0**: If file path doesn't exist, :NERDTreeFind its parent directory instead. (PhilRunninger) [#1043](https://github.com/scrooloose/nerdtree/pull/1043)
 #### 6.0...
 - **.1**: Reintroduce necessary variable mistakenly removed. (PhilRunninger) [#1040](https://github.com/scrooloose/nerdtree/pull/1040)

--- a/autoload/nerdtree.vim
+++ b/autoload/nerdtree.vim
@@ -10,17 +10,20 @@ let s:rootNERDTreePath = resolve(expand("<sfile>:p:h:h"))
 "  change log is shown for the current version; otherwise, only the version
 "  number is shown.
 function! nerdtree#version(...)
-    let l:changelog = readfile(join([s:rootNERDTreePath, "CHANGELOG.md"], nerdtree#slash()))
     let l:text = 'Unknown'
-    let l:line = 0
-    while l:line <= len(l:changelog)
-        if l:changelog[l:line] =~ '\d\+\.\d\+'
-            let l:text = substitute(l:changelog[l:line], '.*\(\d\+.\d\+\).*', '\1', '')
-            let l:text .= substitute(l:changelog[l:line+1], '^.\{-}\(\.\d\+\).\{-}:\(.*\)', a:0>0 ? '\1:\2' : '\1', '')
-            break
-        endif
-        let l:line += 1
-    endwhile
+    try
+        let l:changelog = readfile(join([s:rootNERDTreePath, "CHANGELOG.md"], nerdtree#slash()))
+        let l:line = 0
+        while l:line <= len(l:changelog)
+            if l:changelog[l:line] =~ '\d\+\.\d\+'
+                let l:text = substitute(l:changelog[l:line], '.*\(\d\+.\d\+\).*', '\1', '')
+                let l:text .= substitute(l:changelog[l:line+1], '^.\{-}\(\.\d\+\).\{-}:\(.*\)', a:0>0 ? '\1:\2' : '\1', '')
+                break
+            endif
+            let l:line += 1
+        endwhile
+    catch
+    endtry
     return l:text
 endfunction
 


### PR DESCRIPTION
The ArchLinux package
(https://www.archlinux.org/packages/community/any/vim-nerdtree/) puts
this file in the wrong location.

### Description of Changes
Closes #1044  <!-- Issue number this PR addresses. If none, remove this line. -->

---
### New Version Info

- [x] Derive a new version number. Increment the:
    - [ ] `MAJOR` version when you make incompatible API changes
    - [ ] `MINOR` version when you add functionality in a backwards-compatible manner
    - [x] `PATCH` version when you make backwards-compatible bug fixes
- [x] Update [CHANGELOG.md](https://github.com/scrooloose/nerdtree/blob/master/CHANGELOG.md), following the established pattern.
- [ ] Tag the merge commit, e.g. `git tag -a 3.1.4 -m "v3.1.4" && git push origin --tags`
