### PR TITLE
Wrap saveScreenState's statements in a try-catch block.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log
 
 #### 6.1...
+- **.2**: Wrap saveScreenState's statements in a try-catch block. (PhilRunninger) [#1047](https://github.com/scrooloose/nerdtree/pull/1047)
 - **.1**: Catch errors when trying to read CHANGELOG.md. (PhilRunninger) [#1045](https://github.com/scrooloose/nerdtree/pull/1045)
 - **.0**: If file path doesn't exist, :NERDTreeFind its parent directory instead. (PhilRunninger) [#1043](https://github.com/scrooloose/nerdtree/pull/1043)
 #### 6.0...

--- a/lib/nerdtree/ui.vim
+++ b/lib/nerdtree/ui.vim
@@ -355,12 +355,15 @@ endfunction
 " scroll position
 function! s:UI.saveScreenState()
     let win = winnr()
-    call g:NERDTree.CursorToTreeWin()
     let self._screenState = {}
-    let self._screenState['oldPos'] = getpos(".")
-    let self._screenState['oldTopLine'] = line("w0")
-    let self._screenState['oldWindowSize']= winwidth("")
-    call nerdtree#exec(win . "wincmd w", 1)
+    try
+        call g:NERDTree.CursorToTreeWin()
+        let self._screenState['oldPos'] = getpos(".")
+        let self._screenState['oldTopLine'] = line("w0")
+        let self._screenState['oldWindowSize']= winwidth("")
+        call nerdtree#exec(win . "wincmd w", 1)
+    catch
+    endtry
 endfunction
 
 " FUNCTION: s:UI.setShowHidden(val) {{{1


### PR DESCRIPTION
If you're in NERDTree, and you press : to open a command line, and then
press Ctrl+F to open the [Command Line] window, you will see errors
related to switching windows while in this function. (Those commands are
not allowed while in the [Command Line] window.) The try-catch block
handles the errors, preventing their being displayed.

### Description of Changes
Closes #1046   <!-- Issue number this PR addresses. If none, remove this line. -->

---
### New Version Info

- [x] Derive a new version number. Increment the:
    - [ ] `MAJOR` version when you make incompatible API changes
    - [ ] `MINOR` version when you add functionality in a backwards-compatible manner
    - [x] `PATCH` version when you make backwards-compatible bug fixes
- [x] Update [CHANGELOG.md](https://github.com/scrooloose/nerdtree/blob/master/CHANGELOG.md), following the established pattern.
- [ ] Tag the merge commit, e.g. `git tag -a 3.1.4 -m "v3.1.4" && git push origin --tags`
