### PR TITLE
Menu option, 'copy path to clipboard' is aware of VIM clipboard option

### DIFF
--- a/nerdtree_plugin/fs_menu.vim
+++ b/nerdtree_plugin/fs_menu.vim
@@ -369,7 +369,11 @@ endfunction
 function! NERDTreeCopyPath()
     let l:nodePath = g:NERDTreeFileNode.GetSelected().path.str()
     if has("clipboard")
-        let @* = l:nodePath
+        if &clipboard == "unnamedplus"
+            let @+ = l:nodePath
+        else
+            let @* = l:nodePath
+        endif
         call nerdtree#echo("The path [" . l:nodePath . "] was copied to your clipboard.")
     else
         call nerdtree#echo("The full path is: " . l:nodePath)


### PR DESCRIPTION
VIM noob here, so code might not be optimal.

My setup is as follows.
NVIM v0.5.0-95-g2e14dffbb, Linux Mint 19.2.

I have this in init.vim
```vim
set clipboard=unnamedplus
```
This enables me to share clipboard between VIM and X clipboard.

The problem is that the menu option in NERDTree copies the file path to the "* register.
This means I can't access the value in the X clipboard.