### PR TITLE
Add a NERDTreeToggleVCS command to the vcs plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 -->
 
 #### 6.2
+- **.2**: Add new command to toggle NERDTree defaulting to the root of a VCS repository. (willfindlay) [#1057](https://github.com/scrooloose/nerdtree/pull/1057)
 - **.1**: Menu option, 'copy path to clipboard' is aware of VIM clipboard option (jhzn) [#1056](https://github.com/scrooloose/nerdtree/pull/1056)
 - **.0**: Support tab-specific CWDs (PhilRunninger) [#1032](https://github.com/scrooloose/nerdtree/pull/1032)
 #### 6.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@
     in an unordered list.  The format is:
         - **.PATCH**: Pull Request Title (PR Author) [PR Number](Link to PR)
 -->
-
+#### 6.3
+- **.0**: Add new command that behaves like NERDTreeToggle but defaults to the root of a VCS repository. (willfindlay) [#1060](https://github.com/scrooloose/nerdtree/pull/1060)
 #### 6.2
-- **.2**: Add new command that behaves like NERDTreeToggle but defaults to the root of a VCS repository. (willfindlay) [#1060](https://github.com/scrooloose/nerdtree/pull/1060)
 - **.1**: Menu option, 'copy path to clipboard' is aware of VIM clipboard option (jhzn) [#1056](https://github.com/scrooloose/nerdtree/pull/1056)
 - **.0**: Support tab-specific CWDs (PhilRunninger) [#1032](https://github.com/scrooloose/nerdtree/pull/1032)
 #### 6.1

--- a/doc/NERDTree.txt
+++ b/doc/NERDTree.txt
@@ -125,6 +125,14 @@ The following features and functionality are provided by the NERDTree:
     again.  If no NERDTree exists for this tab then this command acts the
     same as the |:NERDTree| command.
 
+:NERDTreeToggleVCS [<start-directory> | <bookmark>]            *:NERDTreeToggleVCS*
+    Like |:NERDTreeToggle|, but searches up the directory tree to find the top of
+    the version control system repository, and roots the NERDTree there. It
+    works with Git, Subversion, Mercurial, Bazaar, and Darcs repositories. A
+    couple of examples: >
+        :NERDTreeToggleVCS /home/marty/nerdtree/doc  (opens /home/marty/nerdtree)
+        :NERDTreeToggleVCS              (opens root of repository containing CWD)
+
 :NERDTreeFocus                                                  *:NERDTreeFocus*
     Opens (or reopens) the NERDTree if it is not currently visible;
     otherwise, the cursor is moved to the already-open NERDTree.

--- a/nerdtree_plugin/vcs.vim
+++ b/nerdtree_plugin/vcs.vim
@@ -11,12 +11,33 @@
 "
 " ============================================================================
 command! -n=? -complete=dir -bar NERDTreeVCS :call <SID>CreateTabTreeVCS('<args>')
+command! -n=? -complete=dir -bar NERDTreeToggleVCS :call <SID>ToggleTabTreeVCS('<args>')
 
 " FUNCTION: s:CreateTabTreeVCS(a:name) {{{1
 function! s:CreateTabTreeVCS(name)
     let l:path = g:NERDTreeCreator._pathForString(a:name)
     let l:path = s:FindParentVCSRoot(l:path)
     call g:NERDTreeCreator.createTabTree(empty(l:path) ? "" : l:path._str())
+endfunction
+
+" FUNCTION: s:ToggleVCS(a:name) {{{1
+" Behaves the same as ToggleTabTree except roots directory at VCS root
+function! s:ToggleTabTreeVCS(name)
+    let l:path = g:NERDTreeCreator._pathForString(a:name)
+    let l:path = s:FindParentVCSRoot(l:path)
+    if g:NERDTree.ExistsForTab()
+        if !g:NERDTree.IsOpen()
+            call g:NERDTreeCreator._createTreeWin()
+            if !&hidden
+                call b:NERDTree.render()
+            endif
+            call b:NERDTree.ui.restoreScreenState()
+        else
+            call g:NERDTree.Close()
+        endif
+    else
+        call g:NERDTreeCreator.createTabTree(empty(l:path) ? "" : l:path._str())
+    endif
 endfunction
 
 " FUNCTION: s:FindParentVCSRoot(a:path) {{{1

--- a/nerdtree_plugin/vcs.vim
+++ b/nerdtree_plugin/vcs.vim
@@ -20,7 +20,7 @@ function! s:CreateTabTreeVCS(name)
     call g:NERDTreeCreator.createTabTree(empty(l:path) ? "" : l:path._str())
 endfunction
 
-" FUNCTION: s:ToggleVCS(a:name) {{{1
+" FUNCTION: s:ToggleTabTreeVCS(a:name) {{{1
 " Behaves the same as ToggleTabTree except roots directory at VCS root
 function! s:ToggleTabTreeVCS(name)
     let l:path = g:NERDTreeCreator._pathForString(a:name)

--- a/nerdtree_plugin/vcs.vim
+++ b/nerdtree_plugin/vcs.vim
@@ -25,19 +25,7 @@ endfunction
 function! s:ToggleTabTreeVCS(name)
     let l:path = g:NERDTreeCreator._pathForString(a:name)
     let l:path = s:FindParentVCSRoot(l:path)
-    if g:NERDTree.ExistsForTab()
-        if !g:NERDTree.IsOpen()
-            call g:NERDTreeCreator._createTreeWin()
-            if !&hidden
-                call b:NERDTree.render()
-            endif
-            call b:NERDTree.ui.restoreScreenState()
-        else
-            call g:NERDTree.Close()
-        endif
-    else
-        call g:NERDTreeCreator.createTabTree(empty(l:path) ? "" : l:path._str())
-    endif
+    call g:NERDTreeCreator.toggleTabTree(empty(l:path) ? "" : l:path._str())
 endfunction
 
 " FUNCTION: s:FindParentVCSRoot(a:path) {{{1


### PR DESCRIPTION
### Description of Changes

Added a new command NERDTreeToggleVCS to the vcs plugin that behaves exactly like NERDTreeToggle except attempt to root at VCS root when creating the tree for the first time.


---
### New Version Info

#### Author's Instructions
- [x] Derive a new `MAJOR.MINOR.PATCH` version number. Increment the:
    - `MAJOR` version when you make incompatible API changes
    - `MINOR` version when you add functionality in a backwards-compatible manner
    - `PATCH` version when you make backwards-compatible bug fixes
- [x] Update [CHANGELOG.md](https://github.com/scrooloose/nerdtree/blob/master/CHANGELOG.md), following the established pattern.
#### Collaborator's Instructions
- [x] Review [CHANGELOG.md](https://github.com/scrooloose/nerdtree/blob/master/CHANGELOG.md), suggesting a different version number if necessary.
- [ ] After merge, tag the merge commit, e.g. `git tag -a 3.1.4 -m "v3.1.4" && git push origin --tags`
