### PR TITLE
Allow use of function references as callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
     in an unordered list.  The format is:
         - **.PATCH**: Pull Request Title (PR Author) [PR Number](Link to PR)
 -->
+#### 6.4
+- **.0**: Allow use of function references as callbacks (HiPhish) [#1067](https://github.com/scrooloose/nerdtree/pull/1067)
 #### 6.3
 - **.0**: Add new command that behaves like NERDTreeToggle but defaults to the root of a VCS repository. (willfindlay) [#1060](https://github.com/scrooloose/nerdtree/pull/1060)
 #### 6.2

--- a/doc/NERDTree.txt
+++ b/doc/NERDTree.txt
@@ -1315,6 +1315,10 @@ following code conventions are used:
 See this blog post for more details:
  http://got-ravings.blogspot.com/2008/09/vim-pr0n-prototype-based-objects.html
 
+A number of API functions take a callback argument to call. The callback can
+be either a string with the name of a function to call, or a |Funcref| object
+which will be called directly.
+
 ------------------------------------------------------------------------------
 4.1. Key map API                                             *NERDTreeKeymapAPI*
 

--- a/lib/nerdtree/key_map.vim
+++ b/lib/nerdtree/key_map.vim
@@ -66,7 +66,7 @@ endfunction
 "FUNCTION: KeyMap.invoke() {{{1
 "Call the KeyMaps callback function
 function! s:KeyMap.invoke(...)
-    let Callback = function(self.callback)
+    let Callback = type(self.callback) == v:t_func ? self.callback : function(self.callback)
     if a:0
         call Callback(a:1)
     else

--- a/lib/nerdtree/menu_item.vim
+++ b/lib/nerdtree/menu_item.vim
@@ -79,7 +79,7 @@ endfunction
 "specified
 function! s:MenuItem.enabled()
     if self.isActiveCallback != -1
-        return {self.isActiveCallback}()
+        return type(self.isActiveCallback) == v:t_func ? self.isActiveCallback() : {self.isActiveCallback}()
     endif
     return 1
 endfunction
@@ -94,7 +94,11 @@ function! s:MenuItem.execute()
         call mc.showMenu()
     else
         if self.callback != -1
-            call {self.callback}()
+            if type(self.callback) == v:t_func
+                call self.callback()
+            else
+                call {self.callback}()
+            endif
         endif
     endif
 endfunction

--- a/lib/nerdtree/notifier.vim
+++ b/lib/nerdtree/notifier.vim
@@ -14,8 +14,9 @@ endfunction
 function! s:Notifier.NotifyListeners(event, path, nerdtree, params)
     let event = g:NERDTreeEvent.New(a:nerdtree, a:path, a:event, a:params)
 
-    for listener in s:Notifier.GetListenersForEvent(a:event)
-        call {listener}(event)
+    for Listener in s:Notifier.GetListenersForEvent(a:event)
+    	let Callback = type(Listener) == v:t_func ? Listener : function(Listener)
+        call Callback(event)
     endfor
 endfunction
 

--- a/lib/nerdtree/path.vim
+++ b/lib/nerdtree/path.vim
@@ -500,8 +500,9 @@ function! s:Path.ignore(nerdtree)
             endif
         endfor
 
-        for callback in g:NERDTree.PathFilters()
-            if {callback}({'path': self, 'nerdtree': a:nerdtree})
+        for Callback in g:NERDTree.PathFilters()
+            let Callback = type(Callback) == v:t_func ? Callback : function(Callback)
+            if Callback({'path': self, 'nerdtree': a:nerdtree})
                 return 1
             endif
         endfor


### PR DESCRIPTION
### Description of Changes
Closes #1066

---
### New Version Info
Allow use of function references as callbacks instead of only strings in menu API. This approach could be extended in the future to support function references for all callbacks.

#### Author's Instructions
- [x] Derive a new `MAJOR.MINOR.PATCH` version number. Increment the:
    - `MAJOR` version when you make incompatible API changes
    - `MINOR` version when you add functionality in a backwards-compatible manner
    - `PATCH` version when you make backwards-compatible bug fixes
- [x] Update [CHANGELOG.md](https://github.com/scrooloose/nerdtree/blob/master/CHANGELOG.md), following the established pattern.
#### Collaborator's Instructions
- [x] Review [CHANGELOG.md](https://github.com/scrooloose/nerdtree/blob/master/CHANGELOG.md), suggesting a different version number if necessary.
- [ ] After merge, tag the merge commit, e.g. `git tag -a 3.1.4 -m "v3.1.4" && git push origin --tags`
